### PR TITLE
Updating the strategy to set the refresh token in the credentials

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -46,6 +46,7 @@ module OmniAuth
         if access_token.params
           hash.merge!('id_token' => access_token.params['id_token'])
           hash.merge!('token_type' => access_token.params['token_type'])
+          hash.merge!('refresh_token' => access_token.refresh_token) if access_token.refresh_token
         end
         hash
       end

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -162,6 +162,16 @@ describe OmniAuth::Strategies::Auth0 do
         expect(subject.credentials['token'][:access_token]).to eq('OTqSFa9zrh0VRGAZHH4QPJISCoynRwSy9FocUazuaU950EVcISsJo3pST11iTCiI')
         expect(subject.credentials['token'][:token_type]).to eq('bearer')
       end
+      
+      it 'returns the refresh token' do
+        allow(@access_token).to receive(:refresh_token) { "your_refresh_token" }
+        allow(@access_token).to receive(:params) {
+          {
+            'id_token' => "your_id_token",
+            'token_type' => "your_token_type"
+          } }
+        expect(subject.credentials['refresh_token']).to eq('your_refresh_token')
+      end
     end
   end
 end


### PR DESCRIPTION
Note: The scope on the sign in needs to include `offline_access` in order to get the refresh token in the response

This should address the issue noted in #7