### PR TITLE
Pass query string along in authorize_url

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -53,7 +53,8 @@ module OmniAuth
       def authorize_params
         params = super
         params['auth0Client'] = client_info
-        params
+        parse_query = Rack::Utils.parse_query(request.query_string)
+        params.merge(parse_query)
       end
 
       def request_phase

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -80,6 +80,18 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('redirect_uri')
     end
 
+    it 'redirects to hosted login page' do
+      get 'auth/auth0?connection=abcd'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+      expect(redirect_url).to have_query('response_type', 'code')
+      expect(redirect_url).to have_query('state')
+      expect(redirect_url).to have_query('client_id')
+      expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('connection', 'abcd')
+    end
+
     describe 'callback' do
       let(:access_token) { 'access token' }
       let(:expires_in) { 2000 }


### PR DESCRIPTION
Although the documentation https://github.com/auth0/omniauth-auth0#auth-parameters
says you can append query string, it's not added to the authorize_url.
This makes it hard to dynamically specify a connection in app.