### PR TITLE
Update to omniauth-oauth2

### DIFF
--- a/omniauth-auth0.gemspec
+++ b/omniauth-auth0.gemspec
@@ -23,7 +23,7 @@ omniauth-auth0 is the omniauth strategy for Auth0.
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   


### PR DESCRIPTION
Allow usage of omniauth-oauth2, which has several minor updates.