### PR TITLE
Silent authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ Gemfile.lock
 .env
 log/
 tmp/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 .env
 log/
 tmp/
+.idea

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ provider
 
 that will tell it to send those parameters on every Auth request.
 
-Or you can do it for a specific Auth request by adding them in the query parameter of the redirect url:
+Or you can do it for a specific Auth request by adding them in the query parameter of the redirect url. Allowed parameters are `connection` and `prompt`:
 
 ```ruby
 redirect_to '/auth/auth0?connection=google-oauth2'
+redirect_to '/auth/auth0?prompt=none'
 ```
 
 ### Auth Hash

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -55,6 +55,7 @@ module OmniAuth
         params['auth0Client'] = client_info
         parse_query = Rack::Utils.parse_query(request.query_string)
         params['connection'] = parse_query['connection']
+        params['prompt'] = parse_query['prompt']
         params
       end
 


### PR DESCRIPTION
Add silent authentication functionality
Now you can pass `prompt` parameter in `redirect_to` path, and `authorize_params` method will add it to the authorization params.