### PR TITLE
URL should be uppercase outside of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ provider
 
 that will tell it to send those parameters on every Auth request.
 
-Or you can do it for a specific Auth request by adding them in the query parameter of the redirect url. Allowed parameters are `connection` and `prompt`:
+Or you can do it for a specific Auth request by adding them in the query parameter of the redirect URL. Allowed parameters are `connection` and `prompt`:
 
 ```ruby
 redirect_to '/auth/auth0?connection=google-oauth2'


### PR DESCRIPTION
URL should be uppercase in README.md file, since it stands for Uniform Resource Locator. This pull request fix it, issue #64 