### PR TITLE
fix for custom domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -100,7 +100,11 @@ module OmniAuth
 
       # Parse the raw user info.
       def raw_info
-        userinfo_url = options.client_options.userinfo_url
+        userinfo_url = if options.audience.present?
+          options.audience
+        else
+          options.client_options.userinfo_url
+        end
         @raw_info ||= access_token.get(userinfo_url).parsed
       end
 


### PR DESCRIPTION
### Changes

If your application issues an /authorize request with audience=https://login.northwind.com/userinfo, the server will return a Service not found: https://login.northwind.com/userinfo error. This is because even if you set a custom domain the API identifier for the /userinfo endpoint remains https://{YOUR_ORIGINAL_AUTH0_DOMAIN}/userinfo.

To fix this your app should instead use audience=https://{YOUR_ORIGINAL_AUTH0_DOMAIN}/userinfo. You can also remove this audience=[...]/userinfo parameter altogether if your application is flagged as OIDC-Conformant in the OAuth2 tab of the application's Advanced Settings.



### References

- [Docs page on "Service Not Found" for reference](https://auth0.com/docs/custom-domains#-service-not-found-)

### Testing

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
