### PR TITLE
Add telemetry to token endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,10 @@ gem 'rake'
 group :development do
   gem 'dotenv'
   gem 'pry'
+  gem 'rubocop', require: false
   gem 'shotgun'
   gem 'sinatra'
   gem 'thin'
-  gem 'rubocop', require: false
 end
 
 group :test do

--- a/lib/omniauth-auth0.rb
+++ b/lib/omniauth-auth0.rb
@@ -1,2 +1,2 @@
-require 'omniauth-auth0/version' # rubocop:disable Style/FileName
+require 'omniauth-auth0/version'
 require 'omniauth/strategies/auth0'

--- a/lib/omniauth/auth0/telemetry.rb
+++ b/lib/omniauth/auth0/telemetry.rb
@@ -4,26 +4,32 @@ module OmniAuth
   module Auth0
     # Module to provide necessary telemetry for API requests.
     module Telemetry
+
+      # Return a telemetry hash to be encoded and sent to Auth0.
+      # @return hash
       def telemetry
-        @telemetry = {
+        telemetry = {
           name: 'omniauth-auth0',
           version: OmniAuth::Auth0::VERSION,
           env: {
             ruby: RUBY_VERSION
           }
         }
-        add_rails_version
+        add_rails_version telemetry
       end
 
+      # JSON-ify and base64 encode the current telemetry.
+      # @return string
       def telemetry_encoded
-        Base64.urlsafe_encode64(JSON.dump(@telemetry))
+        Base64.urlsafe_encode64(JSON.dump(telemetry))
       end
 
       private
 
-      def add_rails_version
-        return unless Gem.loaded_specs['rails'].respond_to? :version
-        @telemetry[:env][:rails] = Gem.loaded_specs['rails'].version.to_s
+      def add_rails_version(telemetry)
+        return telemetry unless Gem.loaded_specs['rails'].respond_to? :version
+        telemetry[:env][:rails] = Gem.loaded_specs['rails'].version.to_s
+        telemetry
       end
     end
   end

--- a/lib/omniauth/auth0/telemetry.rb
+++ b/lib/omniauth/auth0/telemetry.rb
@@ -1,0 +1,30 @@
+require 'json'
+
+module OmniAuth
+  module Auth0
+    # Module to provide necessary telemetry for API requests.
+    module Telemetry
+      def telemetry
+        @telemetry = {
+          name: 'omniauth-auth0',
+          version: OmniAuth::Auth0::VERSION,
+          env: {
+            ruby: RUBY_VERSION
+          }
+        }
+        add_rails_version
+      end
+
+      def telemetry_encoded
+        Base64.urlsafe_encode64(JSON.dump(@telemetry))
+      end
+
+      private
+
+      def add_rails_version
+        return unless Gem.loaded_specs['rails'].respond_to? :version
+        @telemetry[:env][:rails] = Gem.loaded_specs['rails'].version.to_s
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -84,7 +84,7 @@ module OmniAuth
 
       def build_access_token
         telemetry_header = { 'Auth0-Client' => telemetry_encoded }
-        options.token_params[:headers] = telemetry_header
+        options.token_params.merge!(:headers => telemetry_header)
         super
       end
 

--- a/spec/omniauth/auth0/telemetry_spec.rb
+++ b/spec/omniauth/auth0/telemetry_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'json'
+
+describe OmniAuth::Auth0::Telemetry do
+
+  let(:test_class) { Class.new.extend(OmniAuth::Auth0::Telemetry) }
+
+  describe 'telemetry' do
+
+    it 'should have the correct SDK name' do
+      expect(test_class.telemetry).to have_key(:name)
+      expect(test_class.telemetry[:name]).to eq('omniauth-auth0')
+    end
+
+    it 'should have the correct SDK version' do
+      expect(test_class.telemetry).to have_key(:version)
+      expect(test_class.telemetry[:version]).to eq(OmniAuth::Auth0::VERSION)
+    end
+
+    it 'should include the Ruby version' do
+      expect(test_class.telemetry).to have_key(:env)
+      expect(test_class.telemetry[:env]).to have_key(:ruby)
+      expect(test_class.telemetry[:env][:ruby]).to eq(RUBY_VERSION)
+    end
+
+  end
+
+end

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -79,6 +79,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('state')
       expect(redirect_url).to have_query('client_id')
       expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('auth0Client')
     end
 
     it 'redirects to hosted login page' do
@@ -91,6 +92,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('client_id')
       expect(redirect_url).to have_query('redirect_uri')
       expect(redirect_url).to have_query('connection', 'abcd')
+      expect(redirect_url).to have_query('auth0Client')
     end
 
     describe 'callback' do
@@ -98,6 +100,7 @@ describe OmniAuth::Strategies::Auth0 do
       let(:expires_in) { 2000 }
       let(:token_type) { 'bearer' }
       let(:refresh_token) { 'refresh token' }
+      let(:telemetry_value) { Class.new.extend(OmniAuth::Auth0::Telemetry).telemetry_encoded }
 
       let(:user_id) { 'user identifier' }
       let(:state) { SecureRandom.hex(8) }
@@ -147,6 +150,7 @@ describe OmniAuth::Strategies::Auth0 do
 
       def stub_auth(body)
         stub_request(:post, 'https://samples.auth0.com/oauth/token')
+          .with(headers: { 'Auth0-Client' => telemetry_value })
           .to_return(
             headers: { 'Content-Type' => 'application/json' },
             body: MultiJson.encode(body)


### PR DESCRIPTION
### Changes

- Add `OmniAuth::Auth0::Telemetry` to contain all telemetry-related functionality
- Add override `build_access_token` method to the spec to add the telemetry header

### References

- [OmniAuth OAuth2 strategy parent method](https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L87)
- [Helpful example in OmniAuth-Reddit](https://github.com/jackdempsey/omniauth-reddit/blob/master/lib/omniauth/strategies/reddit.rb#L31)

### Testing

* [x] This change adds unit test coverage for these changes and authorize URL telemetry

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines 
