### PR TITLE
Custom issuer

### DIFF
--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -12,12 +12,13 @@ module OmniAuth
       # Initializer
       # @param options object
       #   options.domain - Application domain.
+      #   options.issuer - Application issuer (optional).
       #   options.client_id - Application Client ID.
       #   options.client_secret - Application Client Secret.
       def initialize(options)
-        temp_domain = URI(options.domain)
-        temp_domain = URI("https://#{options.domain}") unless temp_domain.scheme
-        @issuer = "#{temp_domain}/"
+        # Use custom issuer if provided, otherwise use domain
+        @issuer = uri_string(options.issuer || options.domain)
+        @domain = uri_string(options.domain)
 
         @client_id = options.client_id
         @client_secret = options.client_secret
@@ -97,10 +98,10 @@ module OmniAuth
         jwks_public_cert(jwks_x5c.first)
       end
 
-      # Get a JWKS from the issuer
+      # Get a JWKS from the domain
       # @return void
       def jwks
-        jwks_uri = URI(@issuer + '.well-known/jwks.json')
+        jwks_uri = URI(@domain + '.well-known/jwks.json')
         @jwks ||= json_parse(Net::HTTP.get(jwks_uri))
       end
 
@@ -116,6 +117,15 @@ module OmniAuth
       # @return hash
       def json_parse(json)
         JSON.parse(json, symbolize_names: true)
+      end
+
+      # Parse a URI into the desired string format
+      # @param uri - the URI to parse
+      # @return string
+      def uri_string(uri)
+        temp_domain = URI(uri)
+        temp_domain = URI("https://#{uri}") unless uri.scheme
+        "#{temp_domain}/"
       end
     end
   end

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -16,13 +16,11 @@ module OmniAuth
       #   options.client_id - Application Client ID.
       #   options.client_secret - Application Client Secret.
       def initialize(options)
-        # Use custom issuer if provided, otherwise use domain
-        @issuer = if options.respond_to?(:issuer)
-                    uri_string(options.issuer)
-                  else
-                    uri_string(options.domain)
-                  end
         @domain = uri_string(options.domain)
+
+        # Use custom issuer if provided, otherwise use domain
+        @issuer = @domain
+        @issuer = uri_string(options.issuer) if options.respond_to?(:issuer)
 
         @client_id = options.client_id
         @client_secret = options.client_secret

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -7,7 +7,7 @@ module OmniAuth
   module Auth0
     # JWT Validator class
     class JWTValidator
-      attr_accessor :issuer
+      attr_accessor :issuer, :domain
 
       # Initializer
       # @param options object
@@ -17,7 +17,11 @@ module OmniAuth
       #   options.client_secret - Application Client Secret.
       def initialize(options)
         # Use custom issuer if provided, otherwise use domain
-        @issuer = uri_string(options.issuer || options.domain)
+        @issuer = if options.respond_to?(:issuer)
+                    uri_string(options.issuer)
+                  else
+                    uri_string(options.domain)
+                  end
         @domain = uri_string(options.domain)
 
         @client_id = options.client_id
@@ -124,7 +128,7 @@ module OmniAuth
       # @return string
       def uri_string(uri)
         temp_domain = URI(uri)
-        temp_domain = URI("https://#{uri}") unless uri.scheme
+        temp_domain = URI("https://#{uri}") unless temp_domain.scheme
         "#{temp_domain}/"
       end
     end

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -10,7 +10,6 @@ describe OmniAuth::Auth0::JWTValidator do
   let(:client_id) { 'CLIENT_ID' }
   let(:client_secret) { 'CLIENT_SECRET' }
   let(:domain) { 'samples.auth0.com' }
-  let(:issuer) { 'samples.auth0.com' }
   let(:future_timecode) { 32_503_680_000 }
   let(:past_timecode) { 303_912_000 }
   let(:jwks_kid) { 'NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg' }
@@ -35,9 +34,6 @@ describe OmniAuth::Auth0::JWTValidator do
     jwks_file = File.read("#{current_dir}/../../resources/jwks.json")
     JSON.parse(jwks_file, symbolize_names: true)
   end
-
-  Options = Struct.new(:domain, :client_id, :client_secret)
-  OptionsWithIssuer = Struct.new(:domain, :issuer, :client_id, :client_secret)
 
   #
   # Specs
@@ -124,7 +120,7 @@ describe OmniAuth::Auth0::JWTValidator do
   describe 'JWT verifier custom issuer' do
     context 'same as domain' do
       let(:jwt_validator) do
-        make_jwt_validator(opt_issuer: issuer)
+        make_jwt_validator(opt_issuer: domain)
       end
 
       it 'should have the correct issuer' do
@@ -265,16 +261,12 @@ describe OmniAuth::Auth0::JWTValidator do
   private
 
   def make_jwt_validator(opt_domain: domain, opt_issuer: nil)
-    opts = if opt_issuer.nil?
-             Options.new(opt_domain, client_id, client_secret)
-           else
-             OptionsWithIssuer.new(
-               opt_domain,
-               opt_issuer,
-               client_id,
-               client_secret
-             )
-           end
+    opts = OpenStruct.new(
+      domain: opt_domain,
+      client_id: client_id,
+      client_secret: client_secret
+    )
+    opts[:issuer] = opt_issuer unless opt_issuer.nil?
 
     OmniAuth::Auth0::JWTValidator.new(opts)
   end


### PR DESCRIPTION
### Changes

- Added the ability to specify a custom issuer for JWT validation that differs from the provided domain

### References

- I'm an employee at Atlassian on the Statuspage team. We are using this gem to authenticate with our internal authentication service, however the JWT generated by our internal auth service comes from auth0 servers and not from our internally hosted site. Since we make requests to our internal service, the domain is different from the generated JWT. So, to use this gem this change is necessary or else it will always fail JWT validation.

### Testing

Unit tests have been added to reflect the added change, and we tested locally with our setup.

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
