### PR TITLE
Omit missing params from the authorization request

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -78,7 +78,7 @@ module OmniAuth
       def authorize_params
         params = super
         parsed_query = Rack::Utils.parse_query(request.query_string)
-        ['connection', 'prompt'].each do |key|
+        %w[connection prompt].each do |key|
           params[key] = parsed_query[key] if parsed_query.key?(key)
         end
         params

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -78,8 +78,9 @@ module OmniAuth
       def authorize_params
         params = super
         parsed_query = Rack::Utils.parse_query(request.query_string)
-        params['connection'] = parsed_query['connection']
-        params['prompt'] = parsed_query['prompt']
+        ['connection', 'prompt'].each do |key|
+          params[key] = parsed_query[key] if parsed_query.key?(key)
+        end
         params
       end
 

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -82,6 +82,8 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('client_id')
       expect(redirect_url).to have_query('redirect_uri')
       expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('prompt')
     end
 
     it 'redirects to hosted login page' do
@@ -95,6 +97,21 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('redirect_uri')
       expect(redirect_url).to have_query('connection', 'abcd')
       expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('prompt')
+    end
+
+    it 'redirects to hosted login page with prompt=login' do
+      get 'auth/auth0?prompt=login'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+      expect(redirect_url).to have_query('response_type', 'code')
+      expect(redirect_url).to have_query('state')
+      expect(redirect_url).to have_query('client_id')
+      expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('prompt', 'login')
+      expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection')
     end
 
     describe 'callback' do
@@ -300,7 +317,7 @@ RSpec::Matchers.define :have_query do |key, value|
     uri = redirect_uri(actual)
     query = query(uri)
     if value.nil?
-      query[key].length == 1
+      query.key?(key)
     else
       query[key] == [value]
     end


### PR DESCRIPTION
### Changes

I changed the `OmniAuth::Strategies::Auth0#authorize_params` method to stop appending values for `connection` and `prompt` if those keys weren't present in the parsed query string.

I needed to make this change for my integration with Auth0 to work correctly. I have an Enterprise OIDC connection configured such that the `authorize_endpoint` includes `?prompt=login`, which effectively disables session management by the upstream identity provider. Without this change, OmniAuth would pass `?prompt=` to my tenant's authorized endpoint, which would in turn send `?prompt=` to my upstream OIDC authorize endpoint, despite me having configured it to use `?prompt=login` in the dashboard.

### References

None.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
