### PR TITLE
Only validate id_token if provided

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@ Please describe how this can be tested by reviewers. Be specific about anything 
 * [ ] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 * [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
 * [ ] All existing and new tests complete without errors
-* [ ] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
+* [ ] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -48,10 +48,12 @@ module OmniAuth
           )
         end
 
-        # Make sure the ID token can be verified and decoded.
-        auth0_jwt = OmniAuth::Auth0::JWTValidator.new(options)
-        jwt_decoded = auth0_jwt.decode(credentials['id_token'])
-        fail!(:invalid_id_token) unless jwt_decoded.length
+        if credentials['id_token']
+          # Make sure the ID token can be verified and decoded.
+          auth0_jwt = OmniAuth::Auth0::JWTValidator.new(options)
+          jwt_decoded = auth0_jwt.decode(credentials['id_token'])
+          fail!(:invalid_id_token) unless jwt_decoded.length
+        end
 
         credentials
       end


### PR DESCRIPTION
I am trying to update an app from omniauth-auth0 v2.0.0 to v2.2.0. For some reason, we haven't needed to provide `authorize_params` when we configure the omniauth provider (just the client id, client secret, and domain). We are using Auth0 to provide SSO functionality, and I'm not entirely sure what scopes we should be asking for, since we haven't asked for any so far.

The [changelog for v2.0.0](https://github.com/auth0/omniauth-auth0/blob/master/CHANGELOG.md#v200-2017-01-25) mentions:
> and an `id_token` (scope `openid` is needed for Auth0 to return it)

So I think that I just need to ask for `openid`. But could asking for a new scope have any unintended side effects (perhaps for users who have already authenticated)?

Thanks in advance for the help and guidance!

### Changes

Fixes this error:

```
FATAL Rails : <NoMethodError> undefined method `split' for nil:NilClass
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-auth0-2.2.0/lib/omniauth/auth0/jwt_validator.rb:51:in `token_head'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-auth0-2.2.0/lib/omniauth/auth0/jwt_validator.rb:34:in `decode'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-auth0-2.2.0/lib/omniauth/strategies/auth0.rb:55:in `block in <class:Auth0>'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:109:in `instance_eval'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:109:in `block in compile_stack'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:108:in `each'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:108:in `inject'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:108:in `compile_stack'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:102:in `credentials_stack'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:340:in `credentials'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:350:in `auth_hash'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:372:in `callback_phase'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-oauth2-1.6.0/lib/omniauth/strategies/oauth2.rb:75:in `callback_phase'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:238:in `callback_call'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:189:in `call!'
	/Users/stefan/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:169:in `call'
```

### References

This is related to https://github.com/auth0/omniauth-auth0/issues/86.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors (`rake spec` passed)
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
