### PR TITLE
Fix "NameError: uninitialized constant OmniAuth::Auth0::TokenValidationError"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@ Please describe how this can be tested by reviewers. Be specific about anything 
 * [ ] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 * [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
 * [ ] All existing and new tests complete without errors
-* [ ] All code quality tools/guidelines in the [CONTRIBUTING documentation](CONTRIBUTING.md) have been run/followed
+* [ ] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
 ## [v2.3.0](https://github.com/auth0/omniauth-auth0/tree/v2.3.0) (2020-03-06)
-[Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.3.0...v2.2.0)
+[Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.2.0...v2.3.0)
 
 **Added**
-- Improved OIDC Compliance [\#74](https://github.com/auth0/omniauth-auth0/pull/92) ([davidpatrick](https://github.com/davidpatrick))
+- Improved OIDC Compliance [\#92](https://github.com/auth0/omniauth-auth0/pull/92) ([davidpatrick](https://github.com/davidpatrick))
 
 ## [v2.2.0](https://github.com/auth0/omniauth-auth0/tree/v2.2.0) (2018-04-18)
 [Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.1.0...v2.2.0)

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'uri'
 require 'json'
 require 'omniauth'
+require 'omniauth/auth0/errors'
 
 module OmniAuth
   module Auth0

--- a/omniauth-auth0.gemspec
+++ b/omniauth-auth0.gemspec
@@ -16,8 +16,6 @@ OmniAuth is a library that standardizes multi-provider authentication for web ap
 omniauth-auth0 is the OmniAuth strategy for Auth0.
 }
 
-  s.rubyforge_project = 'omniauth-auth0'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'json'
 require 'jwt'
-require 'omniauth/auth0/errors'
 
 describe OmniAuth::Auth0::JWTValidator do
   #


### PR DESCRIPTION
### Changes

This fixes the following error:

```
NameError: uninitialized constant OmniAuth::Auth0::TokenValidationError
```

in case there's an error inside of `callback_phase`. In our case, the error was a DNS resolution error. This caused the wrong error to display in our exception reporting system (but digging in revealed the DNS error).

```
Faraday::ConnectionFailed: Failed to open TCP connection to xxxxxx.auth0.com:443 (getaddrinfo: Temporary failure in name resolution)
```

I think 2.3.1 should be released with this fix.

### References

N/A

### Testing

rspec still passes.

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
