### PR TITLE
Add support for screen_hint=signup param

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,12 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    codecov (0.1.16)
+    codecov (0.2.7)
+      colorize
       json
       simplecov
-      url
     coderay (1.1.2)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.3.1)
@@ -44,7 +45,7 @@ GEM
     hashdiff (1.0.1)
     hashie (4.1.0)
     jaro_winkler (1.5.4)
-    json (2.3.0)
+    json (2.3.1)
     jwt (2.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -119,7 +120,7 @@ GEM
     shellany (0.0.1)
     shotgun (0.9.2)
       rack (>= 1.0)
-    simplecov (0.18.5)
+    simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
@@ -135,7 +136,6 @@ GEM
     thor (1.0.1)
     tilt (2.0.10)
     unicode-display_width (1.7.0)
-    url (0.3.2)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OmniAuth Auth0
 
-An [OmniAuth](https://github.com/intridea/omniauth) strategy for authenticating with [Auth0](https://auth0.com). This strategy is based on the [OmniAuth OAuth2](https://github.com/omniauth/omniauth-oauth2) strategy. 
+An [OmniAuth](https://github.com/intridea/omniauth) strategy for authenticating with [Auth0](https://auth0.com). This strategy is based on the [OmniAuth OAuth2](https://github.com/omniauth/omniauth-oauth2) strategy.
 
 > :warning:  **Important security note:** This solution uses a 3rd party library with an unresolved [security issue(s)](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284). Please review the details of the vulnerability, including [Auth0](https://github.com/auth0/omniauth-auth0/issues/82 ) and other recommended [mitigations](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284), before implementing the solution.
 
@@ -46,7 +46,7 @@ Then install:
 $ bundle install
 ```
 
-See our [contributing guide](CONTRIBUTING.md) for information on local installation for development. 
+See our [contributing guide](CONTRIBUTING.md) for information on local installation for development.
 
 ## Getting Started
 
@@ -64,7 +64,7 @@ All of these tasks and more are covered in our [Ruby on Rails Quickstart](https:
 To send additional parameters during login, you can specify them when you register the provider:
 
 ```ruby
-provider 
+provider
   :auth0,
   ENV['AUTH0_CLIENT_ID'],
   ENV['AUTH0_CLIENT_SECRET'],
@@ -122,6 +122,17 @@ The Auth0 strategy will provide the standard OmniAuth hash attributes:
 }
 ```
 
+### Query Parameter Options
+
+In some scenarios, you may need to pass specific query parameters to `/authorize`. The following parameters are available to enable this:
+
+- `connection`
+- `connection_scope`
+- `prompt`
+- `screen_hint` (only relevant to New Universal Login Experience)
+
+Simply pass these query parameters to your OmniAuth redirect endpoint to enable their behavior.
+
 ## Contribution
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:
@@ -134,7 +145,7 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 - Use [Community](https://community.auth0.com/) for usage, questions, specific cases.
 - Use [Issues](https://github.com/auth0/omniauth-auth0/issues) here for code-level support and bug reports.
-- Paid customers can use [Support](https://support.auth0.com/) to submit a trouble ticket for production-affecting issues. 
+- Paid customers can use [Support](https://support.auth0.com/) to submit a trouble ticket for production-affecting issues.
 
 ## Vulnerability Reporting
 

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -86,7 +86,7 @@ module OmniAuth
       def authorize_params
         params = super
         parsed_query = Rack::Utils.parse_query(request.query_string)
-        %w[connection connection_scope prompt].each do |key|
+        %w[connection connection_scope prompt screen_hint].each do |key|
           params[key] = parsed_query[key] if parsed_query.key?(key)
         end
 

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -123,6 +123,20 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('connection')
     end
 
+    it 'redirects to hosted login page with screen_hint=signup' do
+      get 'auth/auth0?screen_hint=signup'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+      expect(redirect_url).to have_query('response_type', 'code')
+      expect(redirect_url).to have_query('state')
+      expect(redirect_url).to have_query('client_id')
+      expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('screen_hint', 'signup')
+      expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection')
+    end
+
     describe 'callback' do
       let(:access_token) { 'access token' }
       let(:expires_in) { 2000 }

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -83,7 +83,9 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('redirect_uri')
       expect(redirect_url).not_to have_query('auth0Client')
       expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('connection_scope')
       expect(redirect_url).not_to have_query('prompt')
+      expect(redirect_url).not_to have_query('screen_hint')
     end
 
     it 'redirects to hosted login page' do
@@ -97,7 +99,9 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('redirect_uri')
       expect(redirect_url).to have_query('connection', 'abcd')
       expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection_scope')
       expect(redirect_url).not_to have_query('prompt')
+      expect(redirect_url).not_to have_query('screen_hint')
     end
 
     it 'redirects to the hosted login page with connection_scope' do


### PR DESCRIPTION
### Changes
This adds support for the Hosted Login `screen_hint=signup` parameter. I discovered this issue while implementing Auth0 in a new Rails 6 app using Hosted Login. I noticed others had the same experience, so I thought I'd share my solution.

### References

https://github.com/auth0/omniauth-auth0/issues/87

### Testing

This can be tested by adding the `screen_hint=signup` query parameter to the `/auth/auth0` request. You should be able to observe the `screen_hint` parameter being sent to the Auth0 `/authorize` endpoint.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
