### PR TITLE
Allow GET requests in specs

### DIFF
--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -25,6 +25,13 @@ describe OmniAuth::Strategies::Auth0 do
     )
   end
 
+  around do |t|
+    allowed_request_methods = OmniAuth.config.allowed_request_methods
+    OmniAuth.config.allowed_request_methods = [:post, :get]
+    t.run
+    OmniAuth.config.allowed_request_methods = allowed_request_methods
+  end
+
   describe 'client_options' do
     let(:subject) { auth0.client }
 


### PR DESCRIPTION
### Changes

This is not something anyone should do in production. But in tests, this
allows us to bypass CSRF.

Following [CVE-2015-9284](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284), omniauth now has GET requests disabled by default.
While this is a good behavior in real environments, it's makes things a bit harder in tests, as we'd have to generate a valid CSRF token.

This change allows bypassing it (and running tests on the latest omniauth) by allowing GET requests and keep using them.

### References

See Omniauth CVE: https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284

### Testing

This change changes only the unit tests, not actual behavior.

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
