### PR TITLE
Fixes params passed to authorize [SDK-2232]

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -85,9 +85,8 @@ module OmniAuth
       # Define the parameters used for the /authorize endpoint
       def authorize_params
         params = super
-        parsed_query = Rack::Utils.parse_query(request.query_string)
         %w[connection connection_scope prompt screen_hint].each do |key|
-          params[key] = parsed_query[key] if parsed_query.key?(key)
+          params[key] = request.params[key] if request.params.key?(key)
         end
 
         # Generate nonce


### PR DESCRIPTION
Previously query_string only worked on GET requests to the auth endpoint, this change takes params from GET or POST -- fixes #114 