### PR TITLE
Releases 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v2.4.2](https://github.com/auth0/omniauth-auth0/tree/v2.4.2) (2021-01-19)
+
+[Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.4.1...v2.4.2)
+
+**Fixed**
+- Lock Omniauth to 1.9 in gemspec
+
 ## [v2.4.1](https://github.com/auth0/omniauth-auth0/tree/v2.4.1) (2020-10-08)
 
 [Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.4.0...v2.4.1)

--- a/lib/omniauth-auth0/version.rb
+++ b/lib/omniauth-auth0/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Auth0
-    VERSION = '2.4.1'.freeze
+    VERSION = '2.4.2'.freeze
   end
 end

--- a/omniauth-auth0.gemspec
+++ b/omniauth-auth0.gemspec
@@ -21,8 +21,10 @@ omniauth-auth0 is the OmniAuth strategy for Auth0.
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_runtime_dependency 'omniauth', '~> 1.9'
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
 
   s.add_development_dependency 'bundler'
+  
   s.license = 'MIT'
 end

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -25,13 +25,6 @@ describe OmniAuth::Strategies::Auth0 do
     )
   end
 
-  around do |t|
-    allowed_request_methods = OmniAuth.config.allowed_request_methods
-    OmniAuth.config.allowed_request_methods = [:post, :get]
-    t.run
-    OmniAuth.config.allowed_request_methods = allowed_request_methods
-  end
-
   describe 'client_options' do
     let(:subject) { OmniAuth::Strategies::Auth0.new(
       application,


### PR DESCRIPTION
This library was requiring `omniauth` through `omniauth-oauth2`, this patches 2.4.x with locking `omniauth` to `1.9`.  The new version of `omniauth` introduces a security fix that is a breaking change for some, and we are evaluating on either releasing a minor or a major for.