### PR TITLE
Add login_hint to permitted params

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -84,7 +84,7 @@ module OmniAuth
       # Define the parameters used for the /authorize endpoint
       def authorize_params
         params = super
-        %w[connection connection_scope prompt screen_hint organization invitation].each do |key|
+        %w[connection connection_scope prompt screen_hint login_hint organization invitation].each do |key|
           params[key] = request.params[key] if request.params.key?(key)
         end
 

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -146,6 +146,23 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('connection')
     end
 
+    it 'redirects to hosted login page with login_hint=example@mail.com' do
+      get 'auth/auth0?login_hint=example@mail.com'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+      expect(redirect_url).to have_query('response_type', 'code')
+      expect(redirect_url).to have_query('state')
+      expect(redirect_url).to have_query('client_id')
+      expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('login_hint', 'example@mail.com')
+      expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('connection_scope')
+      expect(redirect_url).not_to have_query('prompt')
+      expect(redirect_url).not_to have_query('screen_hint')
+    end
+
     describe 'callback' do
       let(:access_token) { 'access token' }
       let(:expires_in) { 2000 }

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -92,6 +92,8 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('prompt')
       expect(redirect_url).not_to have_query('screen_hint')
       expect(redirect_url).not_to have_query('login_hint')
+      expect(redirect_url).not_to have_query('organization')
+      expect(redirect_url).not_to have_query('invitation')
     end
 
     it 'redirects to hosted login page' do
@@ -109,6 +111,8 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('prompt')
       expect(redirect_url).not_to have_query('screen_hint')
       expect(redirect_url).not_to have_query('login_hint')
+      expect(redirect_url).not_to have_query('organization')
+      expect(redirect_url).not_to have_query('invitation')
     end
 
     it 'redirects to the hosted login page with connection_scope' do
@@ -133,6 +137,8 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('auth0Client')
       expect(redirect_url).not_to have_query('connection')
       expect(redirect_url).not_to have_query('login_hint')
+      expect(redirect_url).not_to have_query('organization')
+      expect(redirect_url).not_to have_query('invitation')
     end
 
     it 'redirects to hosted login page with screen_hint=signup' do
@@ -147,6 +153,27 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('screen_hint', 'signup')
       expect(redirect_url).not_to have_query('auth0Client')
       expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('login_hint')
+      expect(redirect_url).not_to have_query('organization')
+      expect(redirect_url).not_to have_query('invitation')
+    end
+
+    it 'redirects to hosted login page with organization=TestOrg and invitation=TestInvite' do
+      get 'auth/auth0?organization=TestOrg&invitation=TestInvite'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+      expect(redirect_url).to have_query('response_type', 'code')
+      expect(redirect_url).to have_query('state')
+      expect(redirect_url).to have_query('client_id')
+      expect(redirect_url).to have_query('redirect_uri')
+      expect(redirect_url).to have_query('organization', 'TestOrg')
+      expect(redirect_url).to have_query('invitation', 'TestInvite')
+      expect(redirect_url).not_to have_query('auth0Client')
+      expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('connection_scope')
+      expect(redirect_url).not_to have_query('prompt')
+      expect(redirect_url).not_to have_query('screen_hint')
       expect(redirect_url).not_to have_query('login_hint')
     end
 
@@ -165,6 +192,8 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('connection_scope')
       expect(redirect_url).not_to have_query('prompt')
       expect(redirect_url).not_to have_query('screen_hint')
+      expect(redirect_url).not_to have_query('organization')
+      expect(redirect_url).not_to have_query('invitation')
     end
 
     describe 'callback' do

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -91,6 +91,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('connection_scope')
       expect(redirect_url).not_to have_query('prompt')
       expect(redirect_url).not_to have_query('screen_hint')
+      expect(redirect_url).not_to have_query('login_hint')
     end
 
     it 'redirects to hosted login page' do
@@ -107,6 +108,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('connection_scope')
       expect(redirect_url).not_to have_query('prompt')
       expect(redirect_url).not_to have_query('screen_hint')
+      expect(redirect_url).not_to have_query('login_hint')
     end
 
     it 'redirects to the hosted login page with connection_scope' do
@@ -130,6 +132,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('prompt', 'login')
       expect(redirect_url).not_to have_query('auth0Client')
       expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('login_hint')
     end
 
     it 'redirects to hosted login page with screen_hint=signup' do
@@ -144,6 +147,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to have_query('screen_hint', 'signup')
       expect(redirect_url).not_to have_query('auth0Client')
       expect(redirect_url).not_to have_query('connection')
+      expect(redirect_url).not_to have_query('login_hint')
     end
 
     it 'redirects to hosted login page with login_hint=example@mail.com' do


### PR DESCRIPTION
As a aplication send username/email to auth0 universal login page. Auth0 already have feature to autofil username/email if has been sended.

### Changes
Add `login_hint` on allow list of params of authorize_params

### References
![image](https://user-images.githubusercontent.com/1077589/109692752-a41acd80-7b67-11eb-980d-2dfb0f821888.png)
https://auth0.com/docs/universal-login/new-experience#login

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed

### Workaround

`config/initializers/auth0.rb`
```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  options({
    login_hint: lambda do |env|
      Rack::Utils.parse_query(env['rack.input'].gets)['login_hint']
    end
  })

  provider(
    :auth0,
    auth0_client_id
    auth0_client_secret,
    auth0_domain,
    callback_path: '/auth/auth0/callback',
    authorize_options: ['login_hint']
  )
end
``` 