### PR TITLE
Guidance on org_id validation [SDK-2463]

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Simply pass these query parameters to your OmniAuth redirect endpoint to enable 
 
 ## Examples
 
-### Auth0 Organizations
+### Auth0 Organizations (Closed Beta)
 
-[Organizations](https://auth0.com/docs/organizations) is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
 
 Using Organizations, you can:
 
@@ -175,6 +175,7 @@ provider
   ENV['AUTH0_CLIENT_ID'],
   ENV['AUTH0_CLIENT_SECRET'],
   ENV['AUTH0_DOMAIN'],
+  organizations: ['{AUTH0_ORGANIZATION}']
   {
     authorize_params: {
       scope: 'openid read:users',
@@ -202,6 +203,30 @@ You can then supply those parametrs to a `button_to` or `link_to` helper
     }
 %>
 ```
+#### Validating Organizations when using Organization Login Prompt
+
+When Organization login prompt is enabled on your application, but you haven't specified an Organization for the application's authorization endpoint, the `org_id` claim will be present on the ID token, and should be validated to ensure that the value received is expected or known.
+
+Normally, validating the issuer would be enough to ensure that the token was issued by Auth0, and this check is performed by the SDK. However, in the case of organizations, additional checks should be made so that the organization within an Auth0 tenant is expected.
+
+In particular, the `org_id` claim should be checked to ensure it is a value that is already known to the application. This could be validated against a known list of organization IDs, or perhaps checked in conjunction with the current request URL. e.g. the sub-domain may hint at what organization should be used to validate the ID Token.
+
+Here is an example using it in your `callback` method
+
+```ruby
+  def callback
+    claims = request.env['omniauth.auth']['extra']['raw_info']
+
+    if claims["org"] && claims["org"] !== expected_org
+      redirect_to '/unauthorized', status: 401
+    else
+      session[:userinfo] = claims
+      redirect_to '/dashboard'
+    end
+  end
+```
+
+For more information, please read [Work with Tokens and Organizations](https://auth0.com/docs/organizations/using-tokens) on Auth0 Docs.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -184,24 +184,8 @@ provider
   }
 ```
 
-#### Accepting user invitations
+When passing `openid` to the scope and `organization` to the authorize params, you will receive an ID token on callback with the `org_id` claim.  This claim is validated for you by the SDK.
 
-Auth0 Organizations allow users to be invited using emailed links, which will direct a user back to your application. The URL the user will arrive at is based on your configured `Application Login URI`, which you can change from your Application's settings inside the Auth0 dashboard.
-
-When the user arrives at your application using an invite link, you can expect three query parameters to be provided: `invitation`, `organization`, and `organization_name`. These will always be delivered using a GET request.
-
-You can then supply those parametrs to a `button_to` or `link_to` helper
-
-```ruby
-<%= 
-    button_to 'Login', 'auth/auth0',
-    method: :post,
-    params: {
-      organization: '{YOUR_ORGANIZATION_ID}',
-      invitation: '{INVITE_CODE}'
-    }
-%>
-```
 #### Validating Organizations when using Organization Login Prompt
 
 When Organization login prompt is enabled on your application, but you haven't specified an Organization for the application's authorization endpoint, the `org_id` claim will be present on the ID token, and should be validated to ensure that the value received is expected or known.
@@ -226,6 +210,25 @@ Here is an example using it in your `callback` method
 ```
 
 For more information, please read [Work with Tokens and Organizations](https://auth0.com/docs/organizations/using-tokens) on Auth0 Docs.
+
+#### Accepting user invitations
+
+Auth0 Organizations allow users to be invited using emailed links, which will direct a user back to your application. The URL the user will arrive at is based on your configured `Application Login URI`, which you can change from your Application's settings inside the Auth0 dashboard.
+
+When the user arrives at your application using an invite link, you can expect three query parameters to be provided: `invitation`, `organization`, and `organization_name`. These will always be delivered using a GET request.
+
+You can then supply those parametrs to a `button_to` or `link_to` helper
+
+```ruby
+<%= 
+    button_to 'Login', 'auth/auth0',
+    method: :post,
+    params: {
+      organization: '{YOUR_ORGANIZATION_ID}',
+      invitation: '{INVITE_CODE}'
+    }
+%>
+```
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Simply pass these query parameters to your OmniAuth redirect endpoint to enable 
 
 ## Examples
 
-### Auth0 Organizations (Closed Beta)
+### Auth0 Organizations
 
-Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+[Organizations](https://auth0.com/docs/organizations) is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
 
 Using Organizations, you can:
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ provider
   :auth0,
   ENV['AUTH0_CLIENT_ID'],
   ENV['AUTH0_CLIENT_SECRET'],
-  ENV['AUTH0_DOMAIN'],
-  organizations: ['{AUTH0_ORGANIZATION}']
+  ENV['AUTH0_DOMAIN']
   {
     authorize_params: {
       scope: 'openid read:users',


### PR DESCRIPTION
Adds guidance to validating org_id claim in id tokens when not using org for the authorization endpoint