### PR TITLE
Omniauth-Auth0 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,37 @@
 # Change Log
 
 ## [v3.0.0](https://github.com/auth0/omniauth-auth0/tree/v3.0.0) (2021-04-14)
-Version 3.0 introduces [Omniauth v2.0](https://github.com/omniauth/omniauth/releases/tag/v2.0.0) which addresses [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).  Omniauth now defaults to only allow `POST` as the allowed request_phase method.
+Version 3.0 introduces [Omniauth v2.0](https://github.com/omniauth/omniauth/releases/tag/v2.0.0) which addresses [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284). Omniauth now defaults to only allow `POST` as the allowed request_phase method. This was previously handled through the recommended [mitigation](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) using the `omniauth-rails_csrf_protection v0.x.x` gem to provide CSRF protection.
 
 ### Upgrading to omniauth-rails_csrf_protection v1.0.0
-The [mitigation](https://github.com/auth0/omniauth-auth0/issues/82) to CVE-2015-9284 included using `omniauth-rails_csrf_protection` to provide CSRF protection.  You will need to install this gem and/or upgrade to the latest version 1.x.x
+If you are using `omniauth-rails_csrf_protection` to provide CSRF protection, you will need to be upgrade to `1.x.x`.
 
 ### BREAKING CHANGES
-Now that OmniAuth now defaults to only POST as the allowed request_phase method, you will need to convert any login links to use [form helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_for) with the POST method.
+Now that OmniAuth now defaults to only `POST` as the allowed request_phase method, if you aren't already, you will need to convert any login links to use [form helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_for) with the `POST` method.
 
 ```html+ruby
-# OLD
+# OLD -- GET request
 <a href='/auth/auth0'>Login</a>
 
-# NEW Example #1
+# NEW Example #1 -- POST request
 <%= link_to 'Login', 'auth/auth0', method: :post %>
 
-# NEW Example #2
+# NEW Example #2 -- POST request
 <%= button_to 'Login', 'auth/auth0', method: :post %>
 
-# NEW Example #3
+# NEW Example #3 -- POST request
 <%= form_tag('/auth/auth0', method: :post) do %>
   <button type='submit'></button>
 <% end %>
 ```
 
 ### Allowing GET Requests
-In the scenario you absolutely must use GET requests as an allowed request method for authentication, you can override the protection provided with the followign config override:
+In the scenario you absolutely must use GET requests as an allowed request method for authentication, you can override the protection provided with the following config override:
 
 ```ruby
+# Allowing GET requests will expose you to CVE-2015-9284 
 OmniAuth.config.allowed_request_methods = [:get, :post]
 ```
-
 
 ## [v2.6.0](https://github.com/auth0/omniauth-auth0/tree/v2.6.0) (2021-04-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [v3.0.0](https://github.com/auth0/omniauth-auth0/tree/v3.0.0) (2021-04-14)
+Version 3.0 introduces [Omniauth v2.0](https://github.com/omniauth/omniauth/releases/tag/v2.0.0) which addresses [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).  Omniauth now defaults to only allow `POST` as the allowed request_phase method.
+
+### Upgrading to omniauth-rails_csrf_protection v1.0.0
+The [mitigation](https://github.com/auth0/omniauth-auth0/issues/82) to CVE-2015-9284 included using `omniauth-rails_csrf_protection` to provide CSRF protection.  You will need to install this gem and/or upgrade to the latest version 1.x.x
+
+### BREAKING CHANGES
+Now that OmniAuth now defaults to only POST as the allowed request_phase method, you will need to convert any login links to use [form helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_for) with the POST method.
+
+```html+ruby
+# OLD
+<a href='/auth/auth0'>Login</a>
+
+# NEW Example #1
+<%= link_to 'Login', 'auth/auth0', method: :post %>
+
+# NEW Example #2
+<%= button_to 'Login', 'auth/auth0', method: :post %>
+
+# NEW Example #3
+<%= form_tag('/auth/auth0', method: :post) do %>
+  <button type='submit'></button>
+<% end %>
+```
+
+### Allowing GET Requests
+In the scenario you absolutely must use GET requests as an allowed request method for authentication, you can override the protection provided with the followign config override:
+
+```ruby
+OmniAuth.config.allowed_request_methods = [:get, :post]
+```
+
+
 ## [v2.6.0](https://github.com/auth0/omniauth-auth0/tree/v2.6.0) (2021-04-01)
 
 [Full Changelog](https://github.com/auth0/omniauth-auth0/compare/v2.5.0...v2.6.0)

--- a/lib/omniauth-auth0/version.rb
+++ b/lib/omniauth-auth0/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Auth0
-    VERSION = '2.6.0'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end

--- a/omniauth-auth0.gemspec
+++ b/omniauth-auth0.gemspec
@@ -21,8 +21,8 @@ omniauth-auth0 is the OmniAuth strategy for Auth0.
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth', '~> 1.9'
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
+  s.add_runtime_dependency 'omniauth', '~> 2.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.7'
 
   s.add_development_dependency 'bundler'
   

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 require 'jwt'
 
+OmniAuth.config.allowed_request_methods = [:get, :post]
+
 RSpec.shared_examples 'site has valid domain url' do |url|
   it { expect(subject.site).to eq(url) }
 end


### PR DESCRIPTION
## [v3.0.0](https://github.com/auth0/omniauth-auth0/tree/v3.0.0) (2021-04-14)
Version 3.0 introduces [Omniauth v2.0](https://github.com/omniauth/omniauth/releases/tag/v2.0.0) which addresses [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).  Omniauth now defaults to only allow `POST` as the allowed request_phase method.

### Upgrading to omniauth-rails_csrf_protection v1.0.0
The [mitigation](https://github.com/auth0/omniauth-auth0/issues/82) to CVE-2015-9284 included using `omniauth-rails_csrf_protection` to provide CSRF protection.  You will need to install this gem and/or upgrade to the latest version 1.x.x

### BREAKING CHANGES
Now that OmniAuth now defaults to only POST as the allowed request_phase method, you will need to convert any login links to use [form helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_for) with the POST method.

```html+ruby
# OLD
<a href='/auth/auth0'>Login</a>

# NEW Example #1
<%= link_to 'Login', 'auth/auth0', method: :post %>

# NEW Example #2
<%= button_to 'Login', 'auth/auth0', method: :post %>

# NEW Example #3
<%= form_tag('/auth/auth0', method: :post) do %>
  <button type='submit'></button>
<% end %>
```

### Allowing GET Requests
In the scenario you absolutely must use GET requests as an allowed request method for authentication, you can override the protection provided with the followign config override:

```ruby
OmniAuth.config.allowed_request_methods = [:get, :post]
```