### PR TITLE
fix lint issue - unused variables should prefix with _

### DIFF
--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -66,7 +66,7 @@ module OmniAuth
           raise OmniAuth::Auth0::TokenValidationError.new('ID token could not be decoded')
         end
 
-        id_token, header = decode(jwt)
+        id_token, _header = decode(jwt)
         verify_claims(id_token, authorize_params)
 
         return id_token
@@ -121,9 +121,9 @@ module OmniAuth
 
       def extract_key(head)
         if head[:alg] == 'RS256'
-          key, alg = [rs256_decode_key(head[:kid]), head[:alg]]
+          _key, _alg = [rs256_decode_key(head[:kid]), head[:alg]]
         elsif head[:alg] == 'HS256'
-          key, alg = [@client_secret, head[:alg]]
+          _key, _alg = [@client_secret, head[:alg]]
         else
           raise OmniAuth::Auth0::TokenValidationError.new("Signature algorithm of #{head[:alg]} is not supported. Expected the ID token to be signed with RS256 or HS256")
         end

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -137,7 +137,7 @@ module OmniAuth
         return @raw_info if @raw_info
 
         if access_token["id_token"]
-          claims, header = jwt_validator.decode(access_token["id_token"])
+          claims, _header = jwt_validator.decode(access_token["id_token"])
           @raw_info = claims
         else
           userinfo_url = options.client_options.userinfo_url

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -357,7 +357,7 @@ describe OmniAuth::Auth0::JWTValidator do
         message: "Nonce (nonce) claim value mismatch in the ID token; expected (noncey), found (mismatch)"
       }))
     end
-    
+
     it 'should fail when “aud” is an array of strings and azp claim is not present' do
       aud = [
         client_id,
@@ -524,7 +524,7 @@ describe OmniAuth::Auth0::JWTValidator do
       invalid_kid = 'invalid-kid'
       token = make_rs256_token(payload, invalid_kid)
       expect do
-        verified_token = make_jwt_validator(opt_domain: domain).verify(token)
+        _verified_token = make_jwt_validator(opt_domain: domain).verify(token)
       end.to raise_error(an_instance_of(OmniAuth::Auth0::TokenValidationError).and having_attributes({
         message: "Could not find a public key for Key ID (kid) 'invalid-kid'"
       }))
@@ -542,7 +542,7 @@ describe OmniAuth::Auth0::JWTValidator do
       }
       token = make_rs256_token(payload) + 'bad'
       expect do
-        verified_token = make_jwt_validator(opt_domain: domain).verify(token)
+        _verified_token = make_jwt_validator(opt_domain: domain).verify(token)
       end.to raise_error(an_instance_of(JWT::VerificationError).and having_attributes({
         message: "Signature verification raised"
       }))


### PR DESCRIPTION
### Changes

While going through the code, noticed some lint errors. Variables were defined, but unused. Ruby syntax suggests to prefix such variables with `_`.

### References
https://github.com/rubocop/ruby-style-guide

### Testing
No need

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
