### PR TITLE
Add ui_locales to permitted params

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -84,7 +84,7 @@ module OmniAuth
       # Define the parameters used for the /authorize endpoint
       def authorize_params
         params = super
-        %w[connection connection_scope prompt screen_hint login_hint organization invitation].each do |key|
+        %w[connection connection_scope prompt screen_hint login_hint organization invitation ui_locales].each do |key|
           params[key] = request.params[key] if request.params.key?(key)
         end
 


### PR DESCRIPTION
### Changes

- Allow forwarding of the `ui_locales` parameter to the authoriziation endpoint

### References

This is required to set the language for the Universal Login UI, see https://auth0.com/docs/brand-and-customize/i18n/universal-login-internationalization

### Testing

A request to `/auth/auth0?ui_locales=fr` should result in a french login UI when enabled in the tenant.

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
