### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 matrix_rubyversions: &matrix_rubyversions
   matrix:
     parameters:
-      rubyversion: ["2.5", "2.6", "2.7", "3.0"]
+      rubyversion: ["2.5", "2.6", "2.7", "3.0", "3.1"]
 # Default version of ruby to use for lint and publishing
 default_rubyversion: &default_rubyversion "2.7"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
         type: string
         default: *default_rubyversion
     docker:
-      - image: circleci/ruby:<< parameters.rubyversion >>
+      - image: cimg/ruby:<< parameters.rubyversion >>
 
 jobs:
   run-tests:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -170,7 +171,7 @@ DEPENDENCIES
   simplecov
   sinatra
   thin
-  webmock
+  webmock (>= 3.12.2)
 
 BUNDLED WITH
    2.2.3


### PR DESCRIPTION
### Changes

Adds Ruby 3.1 to the CI matrix.  Ruby 3.1 was released in December 2021.

This PR also includes a minimal changes to the Gemfile.lock introduced when running `bundle; bundle exec rake spec`.  Runs green locally.

### References

[Ruby 3.1 release announcement](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)

### Testing


### Checklist

* [X] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed

Note I'm seeing significant unrelated Rubocop failures.