### PR TITLE
Store plain Hash in session['authorize_params']

### DIFF
--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -94,7 +94,7 @@ module OmniAuth
         params[:leeway] = 60 unless params[:leeway]
 
         # Store authorize params in the session for token verification
-        session['authorize_params'] = params
+        session['authorize_params'] = params.to_hash
 
         params
       end

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -198,6 +198,19 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).not_to have_query('invitation')
     end
 
+    def session
+      session_cookie = last_response.cookies['rack.session'].first
+      session_data, _, _ = session_cookie.rpartition('--')
+      decoded_session_data = Base64.decode64(session_data)
+      Marshal.load(decoded_session_data)
+    end
+
+    it "stores session['authorize_params'] as a plain Ruby Hash" do
+      get '/auth/auth0'
+
+      expect(session['authorize_params'].class).to eq(::Hash)
+    end
+
     describe 'callback' do
       let(:access_token) { 'access token' }
       let(:expires_in) { 2000 }


### PR DESCRIPTION
This PR relates to Auth0 support ticket #01310199.

The `params` object that gets stored in `session['authorize_params']` for token verification is an instance of `OmniAuth::Strategy::Options`, an eventual subclass of `Hashie::Mash`. In reality, it's always treated as a regular hash, and none of `Hashie::Mash`'s features are used.

Since values in the session get serialized into a session store (e.g., `Redis::Store` in our case), this `session['authorize_params]'` value is getting serialized as an instance of `OmniAuth::Strategy::Options`. This causes problems when code that doesn't have the
`OmniAuth::Strategy::Options` class loaded tries to load the session and deserialize its contents. Since this `Options` class is unknown, the code that's loading the session blows up.

This patch simply gets a regular hash from the `params` object before storing it in the session. This way, we're just storing a plain Ruby `Hash`, which is guaranteed to be available by any code that needs to deserialize the session.

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread
- related GitHub issue in this or another repo

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
