### PR TITLE
fix: upgrade to Sinatra 3 and use Rack::Session::Cookie in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'pry', '~> 0'
   gem 'rubocop', '~> 1', require: false
   gem 'shotgun', '~> 0', '>= 0.9.2'
-  gem 'sinatra', '~> 2', '>= 2.2.4'
+  gem 'sinatra', '~> 3'
   gem 'thin', '~> 1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     method_source (1.0.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mustermann (2.0.2)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
     notiffany (0.1.3)
@@ -79,7 +79,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (5.0.1)
     rack (2.2.6.2)
-    rack-protection (2.2.4)
+    rack-protection (3.0.5)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -103,17 +103,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.45.1)
+    rubocop (1.46.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.26.0)
+    rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -129,10 +129,10 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sinatra (2.2.4)
-      mustermann (~> 2.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.4)
+    sinatra (3.0.5)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.5)
       tilt (~> 2.0)
     snaky_hash (2.0.1)
       hashie
@@ -142,7 +142,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (1.2.1)
-    tilt (2.0.11)
+    tilt (2.1.0)
     unicode-display_width (2.4.2)
     version_gem (1.1.1)
     webmock (3.18.1)
@@ -152,9 +152,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   bundler
@@ -172,9 +169,9 @@ DEPENDENCIES
   rubocop (~> 1)
   shotgun (~> 0, >= 0.9.2)
   simplecov-cobertura (~> 2)
-  sinatra (~> 2, >= 2.2.4)
+  sinatra (~> 3)
   thin (~> 1)
   webmock (~> 3)
 
 BUNDLED WITH
-   2.3.26
+   2.3.7

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
         enable :sessions
         set :show_exceptions, false
         set :session_secret, '9771aff2c634257053c62ba072c54754bd2cc92739b37e81c3eda505da48c2ec'
+        set :session_store, Rack::Session::Cookie
       end
 
       use OmniAuth::Builder do


### PR DESCRIPTION
### Changes

This fixes an issue with a test that verifies how the authorization params are written to the session (as a plain hash) that does not work using Sinatra 3. The default session store for 3 [was changed](https://github.com/sinatra/sinatra/pull/1324) `Rack::Protection::EncryptedCookie`, and this test does not take into account the cookie being encrypted.

This PR:

- Upgrades Sinatra to 3
- Uses the Sinatra 2 default cookie store of `Rack::Session::Cookie` for the purposes of tests

### References

Fixes #162

### Testing

This change was tested manually using the `debian:sid` Docker image.
