### PR TITLE
chore: add all build platforms into lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
 
 PLATFORMS
   x86_64-linux
+  aarch64-linux
+  arm64-darwin-21
 
 DEPENDENCIES
   bundler


### PR DESCRIPTION
Adds all the relevant platforms to `Gemfile.lock`. This PR is in combination with setting `BUNDLE_FROZEN=true` in the Circle build, so that it stops trying to write new changes to the lockfile, resulting in uncommitted changes and causing `gem publish` to fail.