### PR TITLE
Update `Gemfile.lock` dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     docile (1.4.0)
     dotenv (2.8.1)
     eventmachine (1.2.7)
-    faraday (2.7.6)
+    faraday (2.7.7)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -79,7 +79,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
-    racc (1.7.0)
+    racc (1.7.1)
     rack (2.2.7)
     rack-protection (3.0.6)
       rack


### PR DESCRIPTION
This PR updates the `Gemfile.lock` dependencies lockfile to resolve Snyk warnings.