### PR TITLE
[SDK-4410] Support Organization Name in JWT validation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Ruby",
-	"image": "mcr.microsoft.com/devcontainers/ruby:3.1",
+	"image": "mcr.microsoft.com/devcontainers/ruby:3.2",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "lts"

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -7,6 +7,7 @@ require 'omniauth/auth0/errors'
 module OmniAuth
   module Auth0
     # JWT Validator class
+    # rubocop:disable Metrics/
     class JWTValidator
       attr_accessor :issuer, :domain
 
@@ -264,12 +265,27 @@ module OmniAuth
       end
 
       def verify_org(id_token, organization)
-        if organization
+        return unless organization
+
+        validate_as_id = organization.start_with? 'org_'
+
+        if validate_as_id
           org_id = id_token['org_id']
           if !org_id || !org_id.is_a?(String)
-            raise OmniAuth::Auth0::TokenValidationError.new("Organization Id (org_id) claim must be a string present in the ID token")
+            raise OmniAuth::Auth0::TokenValidationError, 
+                  'Organization Id (org_id) claim must be a string present in the ID token'
           elsif org_id != organization
-            raise OmniAuth::Auth0::TokenValidationError.new("Organization Id (org_id) claim value mismatch in the ID token; expected '#{organization}', found '#{org_id}'")
+            raise OmniAuth::Auth0::TokenValidationError, 
+                  "Organization Id (org_id) claim value mismatch in the ID token; expected '#{organization}', found '#{org_id}'"
+          end
+        else
+          org_name = id_token['org_name']
+          if !org_name || !org_name.is_a?(String)
+            raise OmniAuth::Auth0::TokenValidationError,
+                  'Organization Name (org_name) claim must be a string present in the ID token'
+          elsif org_name.downcase != organization.downcase
+            raise OmniAuth::Auth0::TokenValidationError,
+                  "Organization Name (org_name) claim value mismatch in the ID token; expected '#{organization}', found '#{org_name}'"
           end
         end
       end

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -529,6 +529,24 @@ describe OmniAuth::Auth0::JWTValidator do
         })))
       end
 
+      it 'should fail when authorize params has organization but token org_name does not match' do
+        payload = {
+          iss: "https://#{domain}/",
+          sub: 'sub',
+          aud: client_id,
+          exp: future_timecode,
+          iat: past_timecode,
+          org_name: 'another-organization'
+        }
+
+        token = make_hs256_token(payload)
+        expect do
+          jwt_validator.verify(token, { organization: 'my-organization' })
+        end.to raise_error(an_instance_of(OmniAuth::Auth0::TokenValidationError).and(having_attributes({
+          message: "Organization Name (org_name) claim value mismatch in the ID token; expected 'my-organization', found 'another-organization'"
+        })))
+      end
+
       it 'should not fail when correctly given an organization ID' do
         payload = {
           iss: "https://#{domain}/",

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -476,7 +476,7 @@ describe OmniAuth::Auth0::JWTValidator do
       expect(id_token['auth_time']).to eq(auth_time)
     end
 
-    context 'Organization claim validation', focus: true do
+    context 'Organization claim validation' do
       it 'should fail when authorize params has organization but org_id is missing in the token' do
         payload = {
           iss: "https://#{domain}/",


### PR DESCRIPTION
### Changes

This PR adds support for `org_name` claim validation in the JWT validator.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
