### PR TITLE
chore: should not lowercase org_name claim

### DIFF
--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -283,7 +283,7 @@ module OmniAuth
           if !org_name || !org_name.is_a?(String)
             raise OmniAuth::Auth0::TokenValidationError,
                   'Organization Name (org_name) claim must be a string present in the ID token'
-          elsif org_name.downcase != organization.downcase
+          elsif org_name != organization.downcase
             raise OmniAuth::Auth0::TokenValidationError,
                   "Organization Name (org_name) claim value mismatch in the ID token; expected '#{organization}', found '#{org_name}'"
           end

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -582,11 +582,11 @@ describe OmniAuth::Auth0::JWTValidator do
           aud: client_id,
           exp: future_timecode,
           iat: past_timecode,
-          org_name: 'MY-ORGANIZATION'
+          org_name: 'my-organization'
         }
 
         token = make_hs256_token(payload)
-        jwt_validator.verify(token, { organization: 'my-organization' })
+        jwt_validator.verify(token, { organization: 'MY-ORGANIZATION' })
       end
     end
     it 'should fail for RS256 token when kid is incorrect' do


### PR DESCRIPTION
`org_name` claim should not be lowercased when performing claim check with `organization`.