### PR TITLE
Add support for client assertion signing key authentication

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-auth0 (3.1.1)
+      jwt (~> 2)
       omniauth (~> 2)
       omniauth-oauth2 (~> 1)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Adding the SDK to your Rails app requires a few steps:
 
 Create the file `./config/auth0.yml` within your application directory with the following content:
 
+### For client secret authentication
+
 ```yml
 development:
   auth0_domain: <YOUR_DOMAIN>
@@ -61,9 +63,24 @@ development:
   auth0_client_secret: <YOUR AUTH0 CLIENT SECRET>
 ```
 
+#### For client assertion signing key authentication
+
+```yml
+development:
+  auth0_domain: <YOUR_DOMAIN>
+  auth0_client_id: <YOUR_CLIENT_ID>
+  auth0_client_assertion_signing_key: <YOUR AUTH0 CLIENT ASSERTION SIGNING PRIVATE KEY>
+  auth0_client_assertion_signing_algorithm: <YOUR AUTH0 CLIENT ASSERTION SIGNING ALGORITHM>
+```
+**Note**: you must upload the corresponding public key to your Auth0 tenant, so that Auth0 is able to verify the JWT signature.
+
+client_assertion_signing_algorithm is optional and defaults to RS256.
+
 ### Create the initializer
 
 Create a new Ruby file in `./config/initializers/auth0.rb` to configure the OmniAuth middleware:
+
+### For client secret authentication
 
 ```ruby
 AUTH0_CONFIG = Rails.application.config_for(:auth0)
@@ -81,6 +98,29 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   )
 end
 ```
+
+#### For client assertion signing key authentication
+
+```ruby
+AUTH0_CONFIG = Rails.application.config_for(:auth0)
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider(
+    :auth0,
+    AUTH0_CONFIG['auth0_client_id'],
+    nil,
+    AUTH0_CONFIG['auth0_domain'],
+    callback_path: '/auth/auth0/callback',
+    authorize_params: {
+      scope: 'openid profile'
+    },
+    client_assertion_signing_key: OpenSSL::PKey::RSA.new(AUTH0_CONFIG[:auth0_client_assertion_signing_key]),
+    client_assertion_signing_algorithm: AUTH0_CONFIG[:auth0_client_assertion_signing_algorithm]
+  )
+end
+```
+
+**Note**: The client_assertion_signing_key must be provided as a PKey object.
 
 ### Create the callback controller
 

--- a/lib/omniauth/auth0/jwt_token.rb
+++ b/lib/omniauth/auth0/jwt_token.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'jwt'
+require 'securerandom'
+
+module OmniAuth
+  module Auth0
+    # JWTToken class to generate a JWT token for client assertion
+    # as per the OAuth 2.0 Client Credentials Grant specification.
+    class JWTToken
+      attr_reader :client_id, :domain_url, :client_assertion_signing_key, :client_assertion_signing_algorithm
+
+      def initialize(client_id, domain_url, client_assertion_signing_key, client_assertion_signing_algorithm = nil)
+        @client_id = client_id
+        @domain_url = domain_url
+        @client_assertion_signing_key = client_assertion_signing_key
+        @client_assertion_signing_algorithm = client_assertion_signing_algorithm || 'RS256'
+      end
+
+      def jwt_token
+        JWT.encode(jwt_payload, client_assertion_signing_key, client_assertion_signing_algorithm)
+      end
+
+      private
+
+      def jwt_payload
+        {
+          iss: client_id,
+          sub: client_id,
+          aud: File.join(domain_url, '/oauth/token'),
+          iat: Time.now.utc.to_i,
+          exp: Time.now.utc.to_i + 60,
+          jti: SecureRandom.uuid
+        }
+      end
+    end
+  end
+end

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -272,10 +272,10 @@ module OmniAuth
         if validate_as_id
           org_id = id_token['org_id']
           if !org_id || !org_id.is_a?(String)
-            raise OmniAuth::Auth0::TokenValidationError, 
+            raise OmniAuth::Auth0::TokenValidationError,
                   'Organization Id (org_id) claim must be a string present in the ID token'
           elsif org_id != organization
-            raise OmniAuth::Auth0::TokenValidationError, 
+            raise OmniAuth::Auth0::TokenValidationError,
                   "Organization Id (org_id) claim value mismatch in the ID token; expected '#{organization}', found '#{org_id}'"
           end
         else

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -4,6 +4,7 @@ require 'base64'
 require 'uri'
 require 'securerandom'
 require 'omniauth-oauth2'
+require 'omniauth/auth0/jwt_token'
 require 'omniauth/auth0/jwt_validator'
 require 'omniauth/auth0/telemetry'
 require 'omniauth/auth0/errors'
@@ -13,6 +14,8 @@ module OmniAuth
     # Auth0 OmniAuth strategy
     class Auth0 < OmniAuth::Strategies::OAuth2
       include OmniAuth::Auth0::Telemetry
+      AUTHORIZATION_CODE_GRANT_TYPE = 'authorization_code'
+      CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
       option :name, 'auth0'
 
@@ -28,6 +31,8 @@ module OmniAuth
         options.client_options.authorize_url = '/authorize'
         options.client_options.token_url = '/oauth/token'
         options.client_options.userinfo_url = '/userinfo'
+        setup_client_options_auth_scheme
+
         super
       end
 
@@ -100,25 +105,20 @@ module OmniAuth
       end
 
       def build_access_token
+        options.token_params.merge!(client_assertion_signing_key_token_params) if client_assertion_signing_key_auth?
         options.token_params[:headers] = { 'Auth0-Client' => telemetry_encoded }
         super
       end
 
       # Declarative override for the request phase of authentication
       def request_phase
-        if no_client_id?
-          # Do we have a client_id for this Application?
-          fail!(:missing_client_id)
-        elsif no_client_secret?
-          # Do we have a client_secret for this Application?
-          fail!(:missing_client_secret)
-        elsif no_domain?
-          # Do we have a domain for this Application?
-          fail!(:missing_domain)
-        else
-          # All checks pass, run the Oauth2 request_phase method.
-          super
-        end
+        return fail!(:missing_client_id) if no_client_id?
+        return fail!(:missing_client_secret) if no_client_secret?
+        return fail!(:missing_domain) if no_domain?
+        return fail!(:missing_client_assertion_signing_key) if no_client_assertion_signing_key?
+
+        # All checks pass, run the Oauth2 request_phase method.
+        super
       end
 
       def callback_phase
@@ -128,8 +128,30 @@ module OmniAuth
       end
 
       private
+
+      def client_assertion_signing_key_auth?
+        options['client_assertion_signing_key']
+      end
+
+      def client_assertion_signing_key_token_params
+        {
+          grant_type: AUTHORIZATION_CODE_GRANT_TYPE,
+          client_id: options.client_id,
+          client_assertion_type: CLIENT_ASSERTION_TYPE,
+          client_assertion: jwt_token
+        }
+      end
+
       def jwt_validator
         @jwt_validator ||= OmniAuth::Auth0::JWTValidator.new(options)
+      end
+
+      def jwt_token
+        OmniAuth::Auth0::JWTToken.new(options.client_id,
+                                      domain_url,
+                                      options.client_assertion_signing_key,
+                                      options.client_assertion_signing_algorithm)
+                                 .jwt_token
       end
 
       # Parse the raw user info.
@@ -154,7 +176,7 @@ module OmniAuth
 
       # Check if the options include a client_secret
       def no_client_secret?
-        ['', nil].include?(options.client_secret)
+        ['', nil].include?(options.client_secret) && !options.key?('client_assertion_signing_key')
       end
 
       # Check if the options include a domain
@@ -162,11 +184,23 @@ module OmniAuth
         ['', nil].include?(options.domain)
       end
 
+      # Check if the options include a client_assertion_signing_key
+      def no_client_assertion_signing_key?
+        options.key?('client_assertion_signing_key') && ['', nil].include?(options.client_assertion_signing_key)
+      end
+
       # Normalize a domain to a URL.
       def domain_url
         domain_url = URI(options.domain)
         domain_url = URI("https://#{domain_url}") if domain_url.scheme.nil?
         domain_url.to_s
+      end
+
+      # Setup the auth_scheme for the client options if using client assertion signing key
+      def setup_client_options_auth_scheme
+        return unless client_assertion_signing_key_auth?
+
+        options.client_options.auth_scheme = :request_body
       end
     end
   end

--- a/omniauth-auth0.gemspec
+++ b/omniauth-auth0.gemspec
@@ -21,6 +21,7 @@ omniauth-auth0 is the OmniAuth strategy for Auth0.
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_runtime_dependency 'jwt', '~> 2'
   s.add_runtime_dependency 'omniauth', '~> 2'
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1'
 

--- a/spec/omniauth/auth0/jwt_token_spec.rb
+++ b/spec/omniauth/auth0/jwt_token_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'jwt'
+
+describe OmniAuth::Auth0::JWTToken do
+  let(:client_id) { 'CLIENT_ID' }
+  let(:domain_url) { 'https://samples.auth0.com' }
+  let(:client_assertion_signing_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+  describe '#jwt_token' do
+    it 'generates a valid JWT token' do
+      uuid = '12345678-1234-5678-1234-567812345678'
+      allow(SecureRandom).to receive(:uuid).and_return(uuid)
+
+      jwt_token = described_class.new(client_id,
+                                      domain_url,
+                                      client_assertion_signing_key,
+                                      'RS256')
+                                 .jwt_token
+      decoded_token = JWT.decode(jwt_token, client_assertion_signing_key, true, { algorithm: 'RS256' })
+
+      expect(decoded_token[0]['iss']).to eq(client_id)
+      expect(decoded_token[0]['sub']).to eq(client_id)
+      expect(decoded_token[0]['aud']).to eq("#{domain_url}/oauth/token")
+      expect(decoded_token[0]['iat']).to be_within(5).of(Time.now.utc.to_i)
+      expect(decoded_token[0]['exp']).to eq(decoded_token[0]['iat'] + 60)
+      expect(decoded_token[0]['jti']).to eq(uuid)
+    end
+
+    it 'defaults to RS256 algorithm if not specified' do
+      uuid = '12345678-1234-5678-1234-567812345678'
+      allow(SecureRandom).to receive(:uuid).and_return(uuid)
+
+      jwt_token = described_class.new(client_id, domain_url, client_assertion_signing_key).jwt_token
+      decoded_token = JWT.decode(jwt_token, client_assertion_signing_key, true, { algorithm: 'RS256' })
+
+      expect(decoded_token[0]['iss']).to eq(client_id)
+      expect(decoded_token[0]['sub']).to eq(client_id)
+      expect(decoded_token[0]['aud']).to eq("#{domain_url}/oauth/token")
+      expect(decoded_token[0]['iat']).to be_within(5).of(Time.now.utc.to_i)
+      expect(decoded_token[0]['exp']).to eq(decoded_token[0]['iat'] + 60)
+      expect(decoded_token[0]['jti']).to eq(uuid)
+    end
+
+    context 'when using ES256 algorithm' do
+      let(:client_assertion_signing_key) { OpenSSL::PKey::EC.generate('prime256v1') }
+
+      it 'generates a valid JWT token' do
+        uuid = '12345678-1234-5678-1234-567812345678'
+        allow(SecureRandom).to receive(:uuid).and_return(uuid)
+        jwt_token = described_class.new(client_id,
+                                        domain_url,
+                                        client_assertion_signing_key,
+                                        'ES256')
+                                   .jwt_token
+        decoded_token = JWT.decode(jwt_token, client_assertion_signing_key, true, { algorithm: 'ES256' })
+
+        expect(decoded_token[0]['iss']).to eq(client_id)
+        expect(decoded_token[0]['sub']).to eq(client_id)
+        expect(decoded_token[0]['aud']).to eq("#{domain_url}/oauth/token")
+        expect(decoded_token[0]['iat']).to be_within(5).of(Time.now.utc.to_i)
+        expect(decoded_token[0]['exp']).to eq(decoded_token[0]['iat'] + 60)
+        expect(decoded_token[0]['jti']).to eq(uuid)
+      end
+
+      it 'accepts client_assertion_signing_key_token_params as a string' do
+        uuid = '12345678-1234-5678-1234-567812345678'
+        allow(SecureRandom).to receive(:uuid).and_return(uuid)
+        jwt_token = described_class.new(client_id,
+                                        domain_url,
+                                        client_assertion_signing_key,
+                                        'ES256')
+                                   .jwt_token
+        decoded_token = JWT.decode(jwt_token, client_assertion_signing_key, true, { algorithm: 'ES256' })
+
+        expect(decoded_token[0]['iss']).to eq(client_id)
+        expect(decoded_token[0]['sub']).to eq(client_id)
+        expect(decoded_token[0]['aud']).to eq("#{domain_url}/oauth/token")
+        expect(decoded_token[0]['iat']).to be_within(5).of(Time.now.utc.to_i)
+        expect(decoded_token[0]['exp']).to eq(decoded_token[0]['iat'] + 60)
+        expect(decoded_token[0]['jti']).to eq(uuid)
+      end
+    end
+  end
+end

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -10,10 +10,231 @@ RSpec.shared_examples 'site has valid domain url' do |url|
   it { expect(subject.site).to eq(url) }
 end
 
+RSpec.shared_examples 'client_options with valid configuration' do
+  context 'domain with https' do
+    let(:domain_url) { 'https://samples.auth0.com' }
+    it_behaves_like 'site has valid domain url', 'https://samples.auth0.com'
+  end
+
+  context 'domain with http' do
+    let(:domain_url) { 'http://mydomain.com' }
+    it_behaves_like 'site has valid domain url', 'http://mydomain.com'
+  end
+
+  context 'domain with host only' do
+    let(:domain_url) { 'samples.auth0.com' }
+    it_behaves_like 'site has valid domain url', 'https://samples.auth0.com'
+  end
+
+  it 'should have correct authorize path' do
+    expect(subject.options[:authorize_url]).to eq('/authorize')
+  end
+
+  it 'should have the correct userinfo path' do
+    expect(subject.options[:userinfo_url]).to eq('/userinfo')
+  end
+
+  it 'should have the correct token path' do
+    expect(subject.options[:token_url]).to eq('/oauth/token')
+  end
+end
+
+RSpec.shared_examples 'oauth redirects with various parameters' do
+  it 'redirects to hosted login page' do
+    get 'auth/auth0'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection')
+    expect(redirect_url).not_to have_query('connection_scope')
+    expect(redirect_url).not_to have_query('prompt')
+    expect(redirect_url).not_to have_query('screen_hint')
+    expect(redirect_url).not_to have_query('login_hint')
+    expect(redirect_url).not_to have_query('organization')
+    expect(redirect_url).not_to have_query('invitation')
+  end
+
+  it 'redirects to hosted login page' do
+    get 'auth/auth0?connection=abcd'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).to have_query('connection', 'abcd')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection_scope')
+    expect(redirect_url).not_to have_query('prompt')
+    expect(redirect_url).not_to have_query('screen_hint')
+    expect(redirect_url).not_to have_query('login_hint')
+    expect(redirect_url).not_to have_query('organization')
+    expect(redirect_url).not_to have_query('invitation')
+  end
+
+  it 'redirects to the hosted login page with connection_scope' do
+    get 'auth/auth0?connection_scope=identity_provider_scope'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url)
+      .to have_query('connection_scope', 'identity_provider_scope')
+  end
+
+  it 'redirects to hosted login page with prompt=login' do
+    get 'auth/auth0?prompt=login'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).to have_query('prompt', 'login')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection')
+    expect(redirect_url).not_to have_query('login_hint')
+    expect(redirect_url).not_to have_query('organization')
+    expect(redirect_url).not_to have_query('invitation')
+  end
+
+  it 'redirects to hosted login page with screen_hint=signup' do
+    get 'auth/auth0?screen_hint=signup'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).to have_query('screen_hint', 'signup')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection')
+    expect(redirect_url).not_to have_query('login_hint')
+    expect(redirect_url).not_to have_query('organization')
+    expect(redirect_url).not_to have_query('invitation')
+  end
+
+  it 'redirects to hosted login page with organization=TestOrg and invitation=TestInvite' do
+    get 'auth/auth0?organization=TestOrg&invitation=TestInvite'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).to have_query('organization', 'TestOrg')
+    expect(redirect_url).to have_query('invitation', 'TestInvite')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection')
+    expect(redirect_url).not_to have_query('connection_scope')
+    expect(redirect_url).not_to have_query('prompt')
+    expect(redirect_url).not_to have_query('screen_hint')
+    expect(redirect_url).not_to have_query('login_hint')
+  end
+
+  it 'redirects to hosted login page with login_hint=example@mail.com' do
+    get 'auth/auth0?login_hint=example@mail.com'
+    expect(last_response.status).to eq(302)
+    redirect_url = last_response.headers['Location']
+    expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
+    expect(redirect_url).to have_query('response_type', 'code')
+    expect(redirect_url).to have_query('state')
+    expect(redirect_url).to have_query('client_id')
+    expect(redirect_url).to have_query('redirect_uri')
+    expect(redirect_url).to have_query('login_hint', 'example@mail.com')
+    expect(redirect_url).not_to have_query('auth0Client')
+    expect(redirect_url).not_to have_query('connection')
+    expect(redirect_url).not_to have_query('connection_scope')
+    expect(redirect_url).not_to have_query('prompt')
+    expect(redirect_url).not_to have_query('screen_hint')
+    expect(redirect_url).not_to have_query('organization')
+    expect(redirect_url).not_to have_query('invitation')
+  end
+
+  it "stores session['authorize_params'] as a plain Ruby Hash" do
+    get '/auth/auth0'
+    expect(session['authorize_params'].class).to eq(::Hash)
+  end
+end
+
+RSpec.shared_examples 'basic oauth callback assertions' do
+  it 'to succeed' do
+    expect(last_response.status).to eq(200)
+  end
+
+  it 'has credentials' do
+    expect(subject['credentials']['token']).to eq(access_token)
+    expect(subject['credentials']['expires']).to be true
+    expect(subject['credentials']['expires_at']).to_not be_nil
+  end
+
+  it 'has basic values' do
+    expect(subject['provider']).to eq('auth0')
+    expect(subject['uid']).to eq(user_id)
+    expect(subject['info']['name']).to eq(name)
+  end
+
+  it 'should use the user info endpoint' do
+    expect(subject['extra']['raw_info']).to eq(basic_user_info)
+  end
+end
+
+RSpec.shared_examples 'basic oauth refresh token callback assertions' do
+  it 'to succeed' do
+    expect(last_response.status).to eq(200)
+  end
+
+  it 'has credentials' do
+    expect(subject['credentials']['token']).to eq(access_token)
+    expect(subject['credentials']['refresh_token']).to eq(refresh_token)
+    expect(subject['credentials']['expires']).to be true
+    expect(subject['credentials']['expires_at']).to_not be_nil
+  end
+end
+
+RSpec.shared_examples 'oidc callback assertions' do
+  it 'to succeed' do
+    expect(last_response.status).to eq(200)
+  end
+
+  it 'has credentials' do
+    expect(subject['credentials']['token']).to eq(access_token)
+    expect(subject['credentials']['expires']).to be true
+    expect(subject['credentials']['expires_at']).to_not be_nil
+    expect(subject['credentials']['id_token']).to eq(id_token)
+  end
+
+  it 'has basic values' do
+    expect(subject['provider']).to eq('auth0')
+    expect(subject['uid']).to eq(user_id)
+  end
+
+  it 'has info' do
+    expect(subject['info']['name']).to eq(name)
+    expect(subject['info']['nickname']).to eq(nickname)
+    expect(subject['info']['image']).to eq(picture)
+    expect(subject['info']['email']).to eq(email)
+  end
+
+  it 'has extra' do
+    expect(subject['extra']['raw_info']['email_verified']).to be true
+  end
+end
+
 describe OmniAuth::Strategies::Auth0 do
   let(:client_id) { 'CLIENT_ID' }
   let(:client_secret) { 'CLIENT_SECRET' }
   let(:domain_url) { 'https://samples.auth0.com' }
+  let(:client_assertion_signing_algorithm) { 'RS256' }
+  let(:client_assertion_signing_key) { OpenSSL::PKey::RSA.generate(2048) }
   let(:application) do
     lambda do
       [200, {}, ['Hello.']]
@@ -27,176 +248,97 @@ describe OmniAuth::Strategies::Auth0 do
       domain_url
     )
   end
-
-  describe 'client_options' do
-    let(:subject) { OmniAuth::Strategies::Auth0.new(
+  let(:auth0_client_assertion_signing_key) do
+    OmniAuth::Strategies::Auth0.new(
       application,
       client_id,
-      client_secret,
-      domain_url
-    ).client }
+      nil,
+      domain_url,
+      { client_assertion_signing_key: client_assertion_signing_key,
+        client_assertion_signing_algorithm: client_assertion_signing_algorithm}
+    )
+  end
+  describe 'client_options' do
+    context 'when using client_secret authentication' do
+      let(:subject) { OmniAuth::Strategies::Auth0.new(
+        application,
+        client_id,
+        client_secret,
+        domain_url
+      ).client }
 
-    context 'domain with https' do
-      let(:domain_url) { 'https://samples.auth0.com' }
-      it_behaves_like 'site has valid domain url', 'https://samples.auth0.com'
+      it_behaves_like 'client_options with valid configuration'
     end
 
-    context 'domain with http' do
-      let(:domain_url) { 'http://mydomain.com' }
-      it_behaves_like 'site has valid domain url', 'http://mydomain.com'
-    end
+    context 'when using client assertion signing key authentication' do
+      let(:subject) do
+        OmniAuth::Strategies::Auth0.new(
+          application,
+          client_id,
+          nil,
+          domain_url,
+          { client_assertion_signing_key: client_assertion_signing_key,
+            client_assertion_signing_algorithm: client_assertion_signing_algorithm }
+        ).client
+      end
 
-    context 'domain with host only' do
-      let(:domain_url) { 'samples.auth0.com' }
-      it_behaves_like 'site has valid domain url', 'https://samples.auth0.com'
-    end
+      it_behaves_like 'client_options with valid configuration'
 
-    it 'should have correct authorize path' do
-      expect(subject.options[:authorize_url]).to eq('/authorize')
-    end
-
-    it 'should have the correct userinfo path' do
-      expect(subject.options[:userinfo_url]).to eq('/userinfo')
-    end
-
-    it 'should have the correct token path' do
-      expect(subject.options[:token_url]).to eq('/oauth/token')
+      it 'should have the correct auth_scheme' do
+        expect(subject.options[:auth_scheme]).to eq(:request_body)
+      end
     end
   end
 
   describe 'options' do
-    let(:subject) { auth0.options }
+    context 'when using client_secret authentication' do
+      let(:subject) { auth0.options }
 
-    it 'should have the correct client_id' do
-      expect(subject[:client_id]).to eq(client_id)
+      it 'should have the correct client_id' do
+        expect(subject[:client_id]).to eq(client_id)
+      end
+
+      it 'should have the correct client secret' do
+        expect(subject[:client_secret]).to eq(client_secret)
+      end
+      it 'should have correct domain' do
+        expect(subject[:domain]).to eq(domain_url)
+      end
     end
 
-    it 'should have the correct client secret' do
-      expect(subject[:client_secret]).to eq(client_secret)
-    end
-    it 'should have correct domain' do
-      expect(subject[:domain]).to eq(domain_url)
+    context 'when using client assertion signing key authentication' do
+      let(:subject) { auth0_client_assertion_signing_key.options }
+
+      it 'should have the correct client_id' do
+        expect(subject[:client_id]).to eq(client_id)
+      end
+
+      it 'should have the correct client secret' do
+        expect(subject[:client_secret]).to eq(nil)
+      end
+      it 'should have correct domain' do
+        expect(subject[:domain]).to eq(domain_url)
+      end
+
+      it 'should have the correct client_assertion_signing_key' do
+        expect(subject[:client_assertion_signing_key]).to eq(client_assertion_signing_key)
+      end
     end
   end
 
   describe 'oauth' do
-    it 'redirects to hosted login page' do
-      get 'auth/auth0'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection')
-      expect(redirect_url).not_to have_query('connection_scope')
-      expect(redirect_url).not_to have_query('prompt')
-      expect(redirect_url).not_to have_query('screen_hint')
-      expect(redirect_url).not_to have_query('login_hint')
-      expect(redirect_url).not_to have_query('organization')
-      expect(redirect_url).not_to have_query('invitation')
+    context 'when using client_secret authentication' do
+      it_behaves_like 'oauth redirects with various parameters'
     end
 
-    it 'redirects to hosted login page' do
-      get 'auth/auth0?connection=abcd'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).to have_query('connection', 'abcd')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection_scope')
-      expect(redirect_url).not_to have_query('prompt')
-      expect(redirect_url).not_to have_query('screen_hint')
-      expect(redirect_url).not_to have_query('login_hint')
-      expect(redirect_url).not_to have_query('organization')
-      expect(redirect_url).not_to have_query('invitation')
-    end
+    context 'when using client assertion signing key authentication' do
+      before do
+        @app = make_application(client_secret: nil,
+                                client_assertion_signing_key: client_assertion_signing_key,
+                                client_assertion_signing_algorithm: client_assertion_signing_algorithm)
+      end
 
-    it 'redirects to the hosted login page with connection_scope' do
-      get 'auth/auth0?connection_scope=identity_provider_scope'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url)
-        .to have_query('connection_scope', 'identity_provider_scope')
-    end
-
-    it 'redirects to hosted login page with prompt=login' do
-      get 'auth/auth0?prompt=login'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).to have_query('prompt', 'login')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection')
-      expect(redirect_url).not_to have_query('login_hint')
-      expect(redirect_url).not_to have_query('organization')
-      expect(redirect_url).not_to have_query('invitation')
-    end
-
-    it 'redirects to hosted login page with screen_hint=signup' do
-      get 'auth/auth0?screen_hint=signup'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).to have_query('screen_hint', 'signup')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection')
-      expect(redirect_url).not_to have_query('login_hint')
-      expect(redirect_url).not_to have_query('organization')
-      expect(redirect_url).not_to have_query('invitation')
-    end
-
-    it 'redirects to hosted login page with organization=TestOrg and invitation=TestInvite' do
-      get 'auth/auth0?organization=TestOrg&invitation=TestInvite'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).to have_query('organization', 'TestOrg')
-      expect(redirect_url).to have_query('invitation', 'TestInvite')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection')
-      expect(redirect_url).not_to have_query('connection_scope')
-      expect(redirect_url).not_to have_query('prompt')
-      expect(redirect_url).not_to have_query('screen_hint')
-      expect(redirect_url).not_to have_query('login_hint')
-    end
-
-    it 'redirects to hosted login page with login_hint=example@mail.com' do
-      get 'auth/auth0?login_hint=example@mail.com'
-      expect(last_response.status).to eq(302)
-      redirect_url = last_response.headers['Location']
-      expect(redirect_url).to start_with('https://samples.auth0.com/authorize')
-      expect(redirect_url).to have_query('response_type', 'code')
-      expect(redirect_url).to have_query('state')
-      expect(redirect_url).to have_query('client_id')
-      expect(redirect_url).to have_query('redirect_uri')
-      expect(redirect_url).to have_query('login_hint', 'example@mail.com')
-      expect(redirect_url).not_to have_query('auth0Client')
-      expect(redirect_url).not_to have_query('connection')
-      expect(redirect_url).not_to have_query('connection_scope')
-      expect(redirect_url).not_to have_query('prompt')
-      expect(redirect_url).not_to have_query('screen_hint')
-      expect(redirect_url).not_to have_query('organization')
-      expect(redirect_url).not_to have_query('invitation')
+      it_behaves_like 'oauth redirects with various parameters'
     end
 
     def session
@@ -204,12 +346,6 @@ describe OmniAuth::Strategies::Auth0 do
       session_data, _, _ = session_cookie.rpartition('--')
       decoded_session_data = Base64.decode64(session_data)
       Marshal.load(decoded_session_data)
-    end
-
-    it "stores session['authorize_params'] as a plain Ruby Hash" do
-      get '/auth/auth0'
-
-      expect(session['authorize_params'].class).to eq(::Hash)
     end
 
     describe 'callback' do
@@ -226,20 +362,6 @@ describe OmniAuth::Strategies::Auth0 do
       let(:picture) { 'some picture url' }
       let(:email) { 'mail@mail.com' }
       let(:email_verified) { true }
-
-      let(:id_token) do
-        payload = {}
-        payload['sub'] = user_id
-        payload['iss'] = "#{domain_url}/"
-        payload['aud'] = client_id
-        payload['name'] = name
-        payload['nickname'] = nickname
-        payload['picture'] = picture
-        payload['email'] = email
-        payload['email_verified'] = email_verified
-
-        JWT.encode payload, client_secret, 'HS256'
-      end
 
       let(:oauth_response) do
         {
@@ -259,15 +381,6 @@ describe OmniAuth::Strategies::Auth0 do
       end
 
       let(:basic_user_info) { { "sub" => user_id, "name" => name } }
-
-      def stub_auth(body)
-        stub_request(:post, 'https://samples.auth0.com/oauth/token')
-          .with(headers: { 'Auth0-Client' => telemetry_value })
-          .to_return(
-            headers: { 'Content-Type' => 'application/json' },
-            body: MultiJson.encode(body)
-          )
-      end
 
       def stub_userinfo(body)
         stub_request(:get, 'https://samples.auth0.com/userinfo')
@@ -290,91 +403,217 @@ describe OmniAuth::Strategies::Auth0 do
         MultiJson.decode(last_response.body)
       end
 
-      context 'basic oauth' do
-        before do
-          stub_auth(oauth_response)
-          stub_userinfo(basic_user_info)
-          trigger_callback
+      context 'when using client_secret authentication' do
+        let(:id_token) do
+          payload = {}
+          payload['sub'] = user_id
+          payload['iss'] = "#{domain_url}/"
+          payload['aud'] = client_id
+          payload['name'] = name
+          payload['nickname'] = nickname
+          payload['picture'] = picture
+          payload['email'] = email
+          payload['email_verified'] = email_verified
+
+          JWT.encode payload, client_secret, 'HS256'
         end
 
-        it 'to succeed' do
-          expect(last_response.status).to eq(200)
+        def stub_auth(body)
+          stub_request(:post, 'https://samples.auth0.com/oauth/token')
+            .with(headers: { 'Auth0-Client' => telemetry_value })
+            .to_return(
+              headers: { 'Content-Type' => 'application/json' },
+              body: MultiJson.encode(body)
+            )
         end
 
-        it 'has credentials' do
-          expect(subject['credentials']['token']).to eq(access_token)
-          expect(subject['credentials']['expires']).to be true
-          expect(subject['credentials']['expires_at']).to_not be_nil
+        context 'basic oauth' do
+          before do
+            stub_auth(oauth_response)
+            stub_userinfo(basic_user_info)
+            trigger_callback
+          end
+
+          it_behaves_like 'basic oauth callback assertions'
         end
 
-        it 'has basic values'  do
-          expect(subject['provider']).to eq('auth0')
-          expect(subject['uid']).to eq(user_id)
-          expect(subject['info']['name']).to eq(name)
+        context 'basic oauth w/refresh token' do
+          before do
+            stub_auth(oauth_response.merge(refresh_token: refresh_token))
+            stub_userinfo(basic_user_info)
+            trigger_callback
+          end
+
+          it_behaves_like 'basic oauth refresh token callback assertions'
         end
 
-        it 'should use the user info endpoint' do
-          expect(subject['extra']['raw_info']).to eq(basic_user_info)
+        context 'oidc' do
+          before do
+            stub_auth(oidc_response)
+            trigger_callback
+          end
+
+          it_behaves_like 'oidc callback assertions'
         end
       end
 
-      context 'basic oauth w/refresh token' do
-        before do
-          stub_auth(oauth_response.merge(refresh_token: refresh_token))
-          stub_userinfo(basic_user_info)
-          trigger_callback
+      context 'when using client assertion signing key authentication' do
+        let(:jwt_token) { JWT.encode({ sub: client_id }, client_assertion_signing_key, 'RS256') }
+        let(:valid_jwks_kid) { 'NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg' }
+
+        let(:rsa_private_key) do
+          OpenSSL::PKey::RSA.generate 2048
         end
 
-        it 'to succeed' do
-          expect(last_response.status).to eq(200)
+        let(:valid_jwks) do
+          {
+            keys: [
+              {
+                kid: valid_jwks_kid,
+                x5c: [Base64.encode64(make_cert(rsa_private_key).to_der)]
+              }
+            ]
+          }.to_json
         end
 
-        it 'has credentials' do
-          expect(subject['credentials']['token']).to eq(access_token)
-          expect(subject['credentials']['refresh_token']).to eq(refresh_token)
-          expect(subject['credentials']['expires']).to be true
-          expect(subject['credentials']['expires_at']).to_not be_nil
-        end
-      end
+        let(:id_token) do
+          payload = {}
+          payload['sub'] = user_id
+          payload['iss'] = "#{domain_url}/"
+          payload['aud'] = client_id
+          payload['name'] = name
+          payload['nickname'] = nickname
+          payload['picture'] = picture
+          payload['email'] = email
+          payload['email_verified'] = email_verified
 
-      context 'oidc' do
-        before do
-          stub_auth(oidc_response)
-          trigger_callback
-        end
-
-        it 'to succeed' do
-          expect(last_response.status).to eq(200)
+          JWT.encode payload, rsa_private_key, 'RS256', kid: valid_jwks_kid
         end
 
-        it 'has credentials' do
-          expect(subject['credentials']['token']).to eq(access_token)
-          expect(subject['credentials']['expires']).to be true
-          expect(subject['credentials']['expires_at']).to_not be_nil
-          expect(subject['credentials']['id_token']).to eq(id_token)
+        def jwt_token?(token)
+          JWT.decode(token, nil, false)
+          true
+        rescue JWT::DecodeError, ArgumentError
+          false
         end
 
-        it 'has basic values' do
-          expect(subject['provider']).to eq('auth0')
-          expect(subject['uid']).to eq(user_id)
+        def make_cert(private_key)
+          cert = OpenSSL::X509::Certificate.new
+          cert.issuer = OpenSSL::X509::Name.parse('/C=BE/O=Auth0/OU=Auth0/CN=Auth0')
+          cert.subject = cert.issuer
+          cert.not_before = Time.now
+          cert.not_after = Time.now + 365 * 24 * 60 * 60
+          cert.public_key = private_key.public_key
+          cert.serial = 0x0
+          cert.version = 2
+
+          ef = OpenSSL::X509::ExtensionFactory.new
+          ef.subject_certificate = cert
+          ef.issuer_certificate = cert
+          cert.extensions = [
+            ef.create_extension('basicConstraints', 'CA:TRUE', true),
+            ef.create_extension('subjectKeyIdentifier', 'hash')
+          ]
+          cert.add_extension ef.create_extension(
+            'authorityKeyIdentifier',
+            'keyid:always,issuer:always'
+          )
+
+          cert.sign private_key, OpenSSL::Digest.new('SHA1')
         end
 
-        it 'has info' do
-          expect(subject['info']['name']).to eq(name)
-          expect(subject['info']['nickname']).to eq(nickname)
-          expect(subject['info']['image']).to eq(picture)
-          expect(subject['info']['email']).to eq(email)
+        def stub_auth(body, stubbed_jwt_token: true)
+          stub_request(:post, "#{domain_url}/oauth/token")
+            .with do |request|
+              params = URI.decode_www_form(request.body).to_h
+              token = params['client_assertion']
+
+              request.headers['Auth0-Client'] == telemetry_value &&
+                params['grant_type'] == described_class::AUTHORIZATION_CODE_GRANT_TYPE &&
+                params['client_id'] == client_id &&
+                params['client_assertion_type'] == described_class::CLIENT_ASSERTION_TYPE &&
+                (stubbed_jwt_token ? token == jwt_token : jwt_token?(token))
+            end
+            .to_return(
+              headers: { 'Content-Type' => 'application/json' },
+              body: MultiJson.encode(body)
+            )
         end
 
-        it 'has extra' do
-          expect(subject['extra']['raw_info']['email_verified']).to be true
+        def stub_expected_jwks
+          stub_request(:get, 'https://samples.auth0.com/.well-known/jwks.json')
+            .to_return(
+              headers: { 'Content-Type' => 'application/json' },
+              body: valid_jwks,
+              status: 200
+            )
+        end
+
+        def stub_jwt_token(algorithm: client_assertion_signing_algorithm)
+          allow(OmniAuth::Auth0::JWTToken).to receive(:new)
+            .with(client_id,
+                  domain_url,
+                  client_assertion_signing_key,
+                  algorithm)
+            .and_return(instance_double(OmniAuth::Auth0::JWTToken, jwt_token: jwt_token))
+        end
+
+        context 'basic oauth' do
+          before do
+            @app = make_application(client_secret: nil, client_assertion_signing_key: client_assertion_signing_key)
+            stub_jwt_token(algorithm: nil)
+            stub_auth(oauth_response)
+            stub_userinfo(basic_user_info)
+            trigger_callback
+          end
+
+          it_behaves_like 'basic oauth callback assertions'
+        end
+
+        context 'basic oath without stubbing jwt token' do
+          before do
+            @app = make_application(client_secret: nil, client_assertion_signing_key: client_assertion_signing_key)
+            stub_auth(oauth_response, stubbed_jwt_token: false)
+            stub_userinfo(basic_user_info)
+            trigger_callback
+          end
+
+          it_behaves_like 'basic oauth callback assertions'
+        end
+
+        context 'basic oauth w/refresh token' do
+          before do
+            @app = make_application(client_secret: nil,
+                                    client_assertion_signing_key: client_assertion_signing_key,
+                                    client_assertion_signing_algorithm: client_assertion_signing_algorithm)
+            stub_jwt_token
+            stub_auth(oauth_response.merge(refresh_token: refresh_token))
+            stub_userinfo(basic_user_info)
+            trigger_callback
+          end
+
+          it_behaves_like 'basic oauth refresh token callback assertions'
+        end
+
+        context 'oidc' do
+          before do
+            @app = make_application(client_secret: nil,
+                                    client_assertion_signing_key: client_assertion_signing_key,
+                                    client_assertion_signing_algorithm: client_assertion_signing_algorithm)
+            stub_jwt_token
+            stub_auth(oidc_response)
+            stub_expected_jwks
+            trigger_callback
+          end
+
+          it_behaves_like 'oidc callback assertions'
         end
       end
     end
   end
 
   describe 'error_handling' do
-    it 'fails when missing client_id' do
+    it 'fails when missing client_id and client_assertion_signing_key' do
       @app = make_application(client_id: nil)
       get 'auth/auth0'
       expect(last_response.status).to eq(302)
@@ -382,7 +621,7 @@ describe OmniAuth::Strategies::Auth0 do
       expect(redirect_url).to fail_auth_with('missing_client_id')
     end
 
-    it 'fails when missing client_secret' do
+    it 'fails when missing client_secret and client_assertion_signing_key' do
       @app = make_application(client_secret: nil)
       get 'auth/auth0'
       expect(last_response.status).to eq(302)
@@ -396,6 +635,14 @@ describe OmniAuth::Strategies::Auth0 do
       expect(last_response.status).to eq(302)
       redirect_url = last_response.headers['Location']
       expect(redirect_url).to fail_auth_with('missing_domain')
+    end
+
+    it 'fails when missing client_assertion_signing_key' do
+      @app = make_application(client_secret: nil, client_assertion_signing_key: nil)
+      get 'auth/auth0'
+      expect(last_response.status).to eq(302)
+      redirect_url = last_response.headers['Location']
+      expect(redirect_url).to fail_auth_with('missing_client_assertion_signing_key')
     end
   end
 end


### PR DESCRIPTION
### Changes

The `omniauth-auth0` gem only supports client secret authentication.  [Auth0 documentation](https://auth0.com/docs/secure/application-credentials#client-secret-authentication) states: 

```
To ​​improve your security posture, we recommend using the Private Key JWT authentication method.
```

Opened issue #199 on 2024-11-07 to inquire about adding support for private key JWT authentication.  We created a workaround to support private key JWT authentication in our application using the `omniauth-auth0` gem.  Opening this PR to get feedback on adding support for private key JWT added to the gem.  

This PR adds two optional parameters to the config: 
 - client_assertion_signing_key - the private key
 - client_assertion_signing_algorithm - algorithm defaults to RS256 

The current interface is preserved. Client secret authentication can be used without changing the interface. 

Client secret authentication: 
```
AUTH0_CONFIG = Rails.application.config_for(:auth0)

Rails.application.config.middleware.use OmniAuth::Builder do
  provider(
    :auth0,
    AUTH0_CONFIG['auth0_client_id'],
    AUTH0_CONFIG['auth0_client_secret'],
    AUTH0_CONFIG['auth0_domain'],
    callback_path: '/auth/auth0/callback',
    authorize_params: {
      scope: 'openid profile'
    }
  )
end
```

Client assertion signing key: 
```
AUTH0_CONFIG = Rails.application.config_for(:auth0)

Rails.application.config.middleware.use OmniAuth::Builder do
  provider(
    :auth0,
    AUTH0_CONFIG['auth0_client_id'],
    nil,
    AUTH0_CONFIG['auth0_domain'],
    callback_path: '/auth/auth0/callback',
    authorize_params: {
      scope: 'openid profile'
    }
    client_assertion_signing_key: AUTH0_CONFIG[:auth0_client_assertion_signing_key],
    client_assertion_signing_algorithm: AUTH0_CONFIG[:auth0_client_assertion_signing_algorithm]}
  )
end
```

The existing code has `rubocop` violations which were not addressed because it was outside the scope of these changes.  No new `rubocop` violations were introduced.  

### References

Please include relevant links supporting this change such as a:

 - issue #199
 - [form post](https://community.auth0.com/t/ruby-on-rails-with-private-key-jwt/150744) https://community.auth0.com/t/ruby-on-rails-with-private-key-jwt/150744 which didn't address the `omniauth-auth0` gem


### Testing

Duplicated all the specs in `spec/omniauth/strategies/auth0_spec.rb` for client assertion signing key.  The existing specs were scoped to 'client secret authentication'.  All specs passed.  

Testing with Auth0 requires an application setup for private key JWT authentication.  The public key must be uploaded to the application in Auth0.  

* [x] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not
   Tested with ruby 3.2.2.  Built the gem and client assertion signing key authentication with a Ruby on Rails application.

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed
