### PR TITLE
fix: Broken release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
-name: Publish Release
+name: Create Release
 
 on:
+  pull_request:
+    types:
+      - closed
   workflow_dispatch:
-    inputs:
-      branch:
-        description: The branch to release from.
-        required: true
-        default: master
-
 
 permissions:
-  contents: read
+  contents: write
   id-token: write # This is required for requesting the JWT
 
 jobs:
@@ -26,7 +23,7 @@ jobs:
       PRODSEC_TOOLS_TOKEN: ${{ secrets.PRODSEC_TOOLS_TOKEN }}
       PRODSEC_TOOLS_ARN: ${{ secrets.PRODSEC_TOOLS_ARN }}
 
-  publish:
+  release:
     uses: ./.github/workflows/ruby-release.yml
     needs: rl-scanner
     with:

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -29,10 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
+        uses: actions/checkout@v6
 
       - name: Configure Ruby
         uses: ./.github/actions/setup

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -20,10 +20,9 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
 
       # Get the version from the branch name
       - id: get_version


### PR DESCRIPTION
### Changes

Fixes the release workflow that was broken when the RL scanner was added (PR #198). The publish pipeline was failing due to missing permissions and incorrect trigger configuration.

- `publish.yml`: Added `pull_request: closed` trigger to enable auto-release on merged release PRs. Changed `contents: read` to `contents: write` to fix AWS OIDC authentication for the RL scanner. Removed unused `workflow_dispatch` branch input.
- `rl-scanner.yml`: Updated `actions/checkout` from v4 to v6, removed hardcoded `ref` and `fetch-depth` overrides.
- `ruby-release.yml`: Updated `actions/checkout` from v4 to v6, removed hardcoded `ref` override.

### References

- PR that introduced the regression: https://github.com/auth0/omniauth-auth0/pull/198

### Testing

CI workflow changes validated by triggering the publish workflow after merge.

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not — CI workflow changes, not applicable for unit testing

### Checklist

* [x] I have read the [Auth0 contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/omniauth-auth0/blob/master/CONTRIBUTING.md) have been run/followed